### PR TITLE
feat: Add listing flow from empty search results

### DIFF
--- a/app/add-listing/page.tsx
+++ b/app/add-listing/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence, Variants, Transition } from 'framer-motion';
+import ListingTypeSelector from '../dashboard/add-listing/components/ListCategory';
+import MultiStepListingForm from '../dashboard/add-listing/components/MultiStepListingForm';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+const AddListingPage = () => {
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+
+  const handleCategorySelect = (category: string) => {
+    setSelectedCategory(category);
+  };
+
+  const handleBack = () => {
+    setSelectedCategory(null);
+  };
+
+  const pageVariants: Variants = {
+    initial: { opacity: 0, x: -50 },
+    in: { opacity: 1, x: 0 },
+    out: { opacity: 0, x: 50 },
+  };
+
+  // ✅ explicitly typed as Transition
+  const pageTransition: Transition = {
+    type: 'tween',
+    ease: 'anticipate',
+    duration: 0.5,
+  };
+
+  return (
+    <section className="w-full max-w-4xl mx-auto py-12">
+      <AnimatePresence mode="wait">
+        {!selectedCategory ? (
+          <motion.div
+            key="category-selector"
+            initial="initial"
+            animate="in"
+            exit="out"
+            variants={pageVariants}
+            transition={pageTransition}
+          >
+            <Card>
+              <CardHeader className="text-center">
+                <CardTitle className="text-3xl font-bold">
+                  Create a New Listing
+                </CardTitle>
+                <CardDescription className="text-lg">
+                  To get started, please select a category for your listing.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <ListingTypeSelector onCategorySelect={handleCategorySelect} />
+              </CardContent>
+            </Card>
+          </motion.div>
+        ) : (
+          <motion.div
+            key="form"
+            initial="initial"
+            animate="in"
+            exit="out"
+            variants={pageVariants}
+            transition={pageTransition}
+          >
+            <MultiStepListingForm
+              category={selectedCategory}
+              onBack={handleBack}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </section>
+  );
+};
+
+export default AddListingPage;

--- a/app/dashboard/add-listing/components/MultiStepListingForm.tsx
+++ b/app/dashboard/add-listing/components/MultiStepListingForm.tsx
@@ -3,6 +3,16 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { motion, AnimatePresence } from 'framer-motion';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Check } from 'lucide-react';
 
 import BasicInfoStep from './BasicInfoStep';
@@ -101,6 +111,7 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
     socials: {},
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isAlertOpen, setIsAlertOpen] = useState(false);
   const router = useRouter();
   const { mutate: addListing, isPending } = useAddListing();
 
@@ -160,7 +171,7 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
     };
     addListing(transformedData, {
       onSuccess: () => {
-        router.push('/dashboard/my-listings');
+        setIsAlertOpen(true);
       },
     });
   };
@@ -176,9 +187,29 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex justify-between items-center">
+    <>
+      <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Verify Your Listing</AlertDialogTitle>
+            <AlertDialogDescription>
+              To verify your listing, a £1 GBP fee is required.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => router.push('/pricing')}
+              className="bg-orange-600 hover:bg-orange-700"
+            >
+              Continue
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <Card>
+        <CardHeader>
+          <div className="flex justify-between items-center">
           <CardTitle className="text-2xl font-bold">
             Create a new <span className="text-primary">{category}</span>{' '}
             Listing
@@ -227,6 +258,7 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
         )}
       </CardFooter>
     </Card>
+    </>
   );
 };
 


### PR DESCRIPTION
Implements a new feature to guide users through creating a new listing when a search on the listings page returns no results.

- When a search has no results, a prominent 'Add New Listing' button is displayed.
- Clicking the button triggers an authentication check. If the user is not logged in, a login/signup modal is shown.
- After authentication, the user's role is validated. If the user is an 'owner', they are redirected to a new 'Add Listing' page.
- The 'Add Listing' page is rendered outside the main dashboard layout.
- Upon successful submission of the new listing form, a dialog is displayed to inform the user about a verification fee.
- The dialog provides an option to continue to the pricing page to complete the payment.