### PR TITLE
feat: Make TrialCountdownTimer draggable

### DIFF
--- a/components/TrialCountdownTimer.tsx
+++ b/components/TrialCountdownTimer.tsx
@@ -66,10 +66,13 @@ const TrialCountdownTimer: React.FC<TrialCountdownTimerProps> = ({
 
   return (
     <motion.div
+      drag
+      dragMomentum={false}
       initial={{ opacity: 0, y: -50 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
-      className="fixed top-4 left-1/2 -translate-x-1/2 z-50 bg-orange-600 text-white p-4 rounded-lg shadow-lg flex items-center space-x-4"
+      className="fixed top-4 left-1/2 -translate-x-1/2 z-50 bg-orange-600 text-white p-4 rounded-lg shadow-lg flex items-center space-x-4 cursor-grab"
+      whileTap={{ cursor: 'grabbing' }}
     >
       <TimerIcon className="w-8 h-8" />
       <div className="flex items-center space-x-2">


### PR DESCRIPTION
This commit makes the TrialCountdownTimer component draggable, allowing users to move it around the screen.

- Added `drag` and `dragMomentum={false}` props to the `motion.div` in `TrialCountdownTimer.tsx`.
- Added `cursor-grab` and `whileTap={{ cursor: 'grabbing' }}` for better user experience.