### PR TITLE
feat: enhance listing form with address and insurance fields

### DIFF
--- a/app/dashboard/add-listing/components/MultiStepListingForm.tsx
+++ b/app/dashboard/add-listing/components/MultiStepListingForm.tsx
@@ -78,6 +78,18 @@ const validationRules = {
       validate: isNotEmpty,
       message: 'Business name is required.',
     },
+    address: {
+      validate: isNotEmpty,
+      message: 'Address is required.',
+    },
+    city: {
+      validate: isNotEmpty,
+      message: 'City is required.',
+    },
+    postcode: {
+      validate: isNotEmpty,
+      message: 'Postcode is required.',
+    },
     shortDesc: {
       validate: (v: string) => isLength(v, { min: 20, max: 180 }),
       message: 'Must be 20-180 characters.',
@@ -89,6 +101,7 @@ const validationRules = {
     email: {
       validate: isValidEmail,
       message: 'Invalid email address.',
+      optional: true,
     },
     'socials.website': {
       validate: isValidUrl,
@@ -139,12 +152,7 @@ const validationRules = {
       message: 'Primary category is required.',
     },
   },
-  productLocation: {
-    address: {
-      validate: isNotEmpty,
-      message: 'Address is required.',
-    },
-  },
+  productLocation: {},
   sellingModes: {
     'productData.sellingModes': {
       validate: (modes: { [s: string]: boolean }) =>
@@ -437,7 +445,10 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
         continue;
       }
 
-      if (rule.optional && (value === undefined || value === null || value === '')) {
+      if (
+        rule.optional &&
+        (value === undefined || value === null || value === '')
+      ) {
         continue;
       }
 
@@ -476,8 +487,8 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
     // --- Location and Service Area ---
     const location: CreateBusinessPayload['location'] = {
       addressLine1: data.address || '',
-      postcode: '', // Note: No postcode in ListingFormData, needs to be extracted from address
-      city: '', // Note: No city in ListingFormData, needs to be extracted from address
+      postcode: data.postcode || '',
+      city: data.city || '',
       showPublicly: data.productData?.showAddressPublicly || false,
       deliveryRadiusKm:
         data.productData?.deliveryArea?.type === 'radius'
@@ -572,7 +583,7 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
         sellingModes,
         fulfilmentNotes: data.productData.fulfilmentNotes,
         returnsPolicy: data.productData.returnsPolicy,
-        hasAgeRestrictedItems: false, // This is not in the form data
+        hasAgeRestrictedItems: !!data.productData.hasAgeRestrictedItems,
         storefrontLinks,
       };
     }
@@ -595,7 +606,8 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
         bookingMethod: apiBookingMethod,
         bookingUrl: data.serviceData.bookingURL,
         quoteOnly: data.serviceData.pricingVisibility === 'quote',
-        hasPublicLiabilityInsurance: false, // This is not in the form data
+        hasPublicLiabilityInsurance:
+          !!data.serviceData.hasPublicLiabilityInsurance,
         certifications: [], // File upload needed
       };
     }

--- a/app/dashboard/add-listing/components/steps/product/ProductLocationStep.tsx
+++ b/app/dashboard/add-listing/components/steps/product/ProductLocationStep.tsx
@@ -22,16 +22,16 @@ interface StepProps {
 }
 
 const isFieldOptional = (schema: z.ZodSchema<unknown>, fieldName: string) => {
-    if (!schema || !('shape' in schema)) {
-      return true; // Default to optional if schema is not as expected
-    }
-    const fieldSchema = (schema as z.ZodObject<z.ZodRawShape>).shape[fieldName];
-    if (!fieldSchema) {
-        return true;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (fieldSchema as any)._def.typeName === 'ZodOptional';
-  };
+  if (!schema || !('shape' in schema)) {
+    return true; // Default to optional if schema is not as expected
+  }
+  const fieldSchema = (schema as z.ZodObject<z.ZodRawShape>).shape[fieldName];
+  if (!fieldSchema) {
+    return true;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (fieldSchema as any)._def.typeName === 'ZodOptional';
+};
 
 const ProductLocationStep: React.FC<StepProps> = ({
   formData,
@@ -56,9 +56,7 @@ const ProductLocationStep: React.FC<StepProps> = ({
 
   const handleProductDataChange = (
     key: string,
-    value:
-      | boolean
-      | { type: 'radius' | 'postcodes'; value: string | string[] }
+    value: boolean | { type: 'radius' | 'postcodes'; value: string | string[] }
   ) => {
     setFormData(prev => ({
       ...prev,
@@ -83,9 +81,7 @@ const ProductLocationStep: React.FC<StepProps> = ({
     });
   };
 
-  const handlePostcodeKeyDown = (
-    e: React.KeyboardEvent<HTMLInputElement>
-  ) => {
+  const handlePostcodeKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && postcode.trim()) {
       e.preventDefault();
       const newPostcodes = [
@@ -112,24 +108,7 @@ const ProductLocationStep: React.FC<StepProps> = ({
   return (
     <div className="space-y-6">
       <div>
-        <Label htmlFor="address">
-            Business Address (Manual Entry)
-            {isFieldOptional(schema!, 'address') && (
-                <span className="text-muted-foreground font-normal text-sm">
-                    {' '}
-                    (optional)
-                </span>
-            )}
-        </Label>
-        <div className="space-y-2 mt-2">
-          <Input
-            id="address"
-            placeholder="e.g., 123 High Street, London, SW1A 1AA"
-            value={formData.address || ''}
-            onChange={handleAddressChange}
-          />
-        </div>
-        <div className="flex items-center space-x-2 mt-4">
+        <div className="flex items-center space-x-2 mt-2">
           <Switch
             id="showAddressPublicly"
             checked={productData.showAddressPublicly !== false}
@@ -139,21 +118,18 @@ const ProductLocationStep: React.FC<StepProps> = ({
           />
           <Label htmlFor="showAddressPublicly">Show address publicly</Label>
         </div>
-        {errors.address && (
-          <p className="text-sm text-red-500 mt-1">{errors.address}</p>
-        )}
       </div>
 
       <div className="border-t pt-6">
         <div className="flex items-center space-x-2">
           <Label>
-              Set Delivery Area
-                {isFieldOptional(schema!, 'productData.deliveryArea') && (
-                    <span className="text-muted-foreground font-normal text-sm">
-                        {' '}
-                        (optional)
-                    </span>
-                )}
+            Set Delivery Area
+            {isFieldOptional(schema!, 'productData.deliveryArea') && (
+              <span className="text-muted-foreground font-normal text-sm">
+                {' '}
+                (optional)
+              </span>
+            )}
           </Label>
           <TooltipProvider>
             <Tooltip>

--- a/app/dashboard/add-listing/components/steps/product/SellingModesStep.tsx
+++ b/app/dashboard/add-listing/components/steps/product/SellingModesStep.tsx
@@ -4,6 +4,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import {
   Card,
   CardContent,
@@ -43,6 +44,7 @@ const SellingModesStep: React.FC<StepProps> = ({
     ukWideShipping: false,
   };
   const storefrontLinks = productData.storefrontLinks || {};
+  const hasAgeRestrictedItems = productData.hasAgeRestrictedItems || false;
 
   const handleSellingModeChange = (
     id: keyof ProductSellerData['sellingModes'],
@@ -67,16 +69,18 @@ const SellingModesStep: React.FC<StepProps> = ({
     });
   };
 
-  const handleProductDataChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      const { id, value } = e.target;
-      setFormData(prev => ({
-          ...prev,
-          productData: {
-              ...prev.productData,
-              [id]: value,
-          }
-      }))
-  }
+  const handleProductDataChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    const { id, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      productData: {
+        ...prev.productData,
+        [id]: value,
+      },
+    }));
+  };
 
   const handleStorefrontLinkChange = (
     e: React.ChangeEvent<HTMLInputElement>
@@ -90,6 +94,16 @@ const SellingModesStep: React.FC<StepProps> = ({
           ...(prev.productData?.storefrontLinks || {}),
           [id]: value,
         },
+      },
+    }));
+  };
+
+  const handleToggleAgeRestricted = (checked: boolean) => {
+    setFormData(prev => ({
+      ...prev,
+      productData: {
+        ...prev.productData,
+        hasAgeRestrictedItems: checked,
       },
     }));
   };
@@ -108,7 +122,9 @@ const SellingModesStep: React.FC<StepProps> = ({
             <Checkbox
               id="inStorePickup"
               checked={sellingModes.inStorePickup}
-              onCheckedChange={(checked) => handleSellingModeChange('inStorePickup', !!checked)}
+              onCheckedChange={checked =>
+                handleSellingModeChange('inStorePickup', !!checked)
+              }
             />
             <Label htmlFor="inStorePickup">In-store Pickup</Label>
           </div>
@@ -116,7 +132,9 @@ const SellingModesStep: React.FC<StepProps> = ({
             <Checkbox
               id="localDelivery"
               checked={sellingModes.localDelivery}
-              onCheckedChange={(checked) => handleSellingModeChange('localDelivery', !!checked)}
+              onCheckedChange={checked =>
+                handleSellingModeChange('localDelivery', !!checked)
+              }
             />
             <Label htmlFor="localDelivery">Local Delivery</Label>
           </div>
@@ -124,11 +142,17 @@ const SellingModesStep: React.FC<StepProps> = ({
             <Checkbox
               id="ukWideShipping"
               checked={sellingModes.ukWideShipping}
-              onCheckedChange={(checked) => handleSellingModeChange('ukWideShipping', !!checked)}
+              onCheckedChange={checked =>
+                handleSellingModeChange('ukWideShipping', !!checked)
+              }
             />
             <Label htmlFor="ukWideShipping">UK-wide Shipping</Label>
           </div>
-          {errors['productData.sellingModes'] && <p className="text-sm text-red-500">{errors['productData.sellingModes']}</p>}
+          {errors['productData.sellingModes'] && (
+            <p className="text-sm text-red-500">
+              {errors['productData.sellingModes']}
+            </p>
+          )}
         </CardContent>
       </Card>
 
@@ -137,6 +161,16 @@ const SellingModesStep: React.FC<StepProps> = ({
           <CardTitle>Additional Information</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="hasAgeRestrictedItems"
+              checked={!!hasAgeRestrictedItems}
+              onCheckedChange={handleToggleAgeRestricted}
+            />
+            <Label htmlFor="hasAgeRestrictedItems">
+              Contains age-restricted items
+            </Label>
+          </div>
           <div>
             <Label htmlFor="fulfilmentNotes">
               Fulfilment Notes
@@ -160,7 +194,10 @@ const SellingModesStep: React.FC<StepProps> = ({
           <div>
             <Label htmlFor="returnsPolicy">
               Returns Policy
-              {isFieldOptional(validationRules, 'productData.returnsPolicy') && (
+              {isFieldOptional(
+                validationRules,
+                'productData.returnsPolicy'
+              ) && (
                 <span className="text-muted-foreground font-normal text-sm">
                   {' '}
                   (optional)

--- a/app/dashboard/add-listing/components/steps/service/BookingStep.tsx
+++ b/app/dashboard/add-listing/components/steps/service/BookingStep.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { ListingFormData } from '../../../types';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { z } from 'zod';
 
 interface StepProps {
@@ -14,16 +21,16 @@ interface StepProps {
 }
 
 const isFieldOptional = (schema: z.ZodSchema<unknown>, fieldName: string) => {
-    if (!schema || !('shape' in schema)) {
-      return true; // Default to optional if schema is not as expected
-    }
-    const fieldSchema = (schema as z.ZodObject<z.ZodRawShape>).shape[fieldName];
-    if (!fieldSchema) {
-        return true;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (fieldSchema as any)._def.typeName === 'ZodOptional';
-  };
+  if (!schema || !('shape' in schema)) {
+    return true; // Default to optional if schema is not as expected
+  }
+  const fieldSchema = (schema as z.ZodObject<z.ZodRawShape>).shape[fieldName];
+  if (!fieldSchema) {
+    return true;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (fieldSchema as any)._def.typeName === 'ZodOptional';
+};
 
 const BookingStep: React.FC<StepProps> = ({
   formData,
@@ -34,6 +41,7 @@ const BookingStep: React.FC<StepProps> = ({
   const serviceData = formData.serviceData || {};
   const bookingMethod = serviceData.bookingMethod || 'call';
   const pricingVisibility = serviceData.pricingVisibility || 'quote';
+  const hasPublicLiabilityInsurance = !!serviceData.hasPublicLiabilityInsurance;
 
   const handleServiceDataChange = (key: string, value: string) => {
     setFormData(prev => ({
@@ -45,25 +53,37 @@ const BookingStep: React.FC<StepProps> = ({
     }));
   };
 
+  const handleInsuranceToggle = (checked: boolean) => {
+    setFormData(prev => ({
+      ...prev,
+      serviceData: {
+        ...prev.serviceData,
+        hasPublicLiabilityInsurance: checked,
+      },
+    }));
+  };
+
   return (
     <div className="space-y-6">
       <Card>
         <CardHeader>
           <CardTitle>Booking Method</CardTitle>
           <CardDescription>
-              How should customers book your services?
-                {isFieldOptional(schema!, 'serviceData.bookingMethod') && (
-                    <span className="text-muted-foreground font-normal text-sm">
-                        {' '}
-                        (optional)
-                    </span>
-                )}
+            How should customers book your services?
+            {isFieldOptional(schema!, 'serviceData.bookingMethod') && (
+              <span className="text-muted-foreground font-normal text-sm">
+                {' '}
+                (optional)
+              </span>
+            )}
           </CardDescription>
         </CardHeader>
         <CardContent>
           <RadioGroup
             value={bookingMethod}
-            onValueChange={(value) => handleServiceDataChange('bookingMethod', value)}
+            onValueChange={value =>
+              handleServiceDataChange('bookingMethod', value)
+            }
             className="space-y-2"
           >
             <div className="flex items-center space-x-2">
@@ -82,24 +102,30 @@ const BookingStep: React.FC<StepProps> = ({
           {bookingMethod === 'online' && (
             <div className="mt-4">
               <Label htmlFor="bookingURL">
-                  Booking URL
-                    {isFieldOptional(schema!, 'serviceData.bookingURL') && (
-                        <span className="text-muted-foreground font-normal text-sm">
-                            {' '}
-                            (optional)
-                        </span>
-                    )}
+                Booking URL
+                {isFieldOptional(schema!, 'serviceData.bookingURL') && (
+                  <span className="text-muted-foreground font-normal text-sm">
+                    {' '}
+                    (optional)
+                  </span>
+                )}
               </Label>
               <Input
                 id="bookingURL"
                 type="url"
                 placeholder="https://yourbookingplatform.com"
                 value={serviceData.bookingURL || ''}
-                onChange={(e) => handleServiceDataChange('bookingURL', e.target.value)}
+                onChange={e =>
+                  handleServiceDataChange('bookingURL', e.target.value)
+                }
               />
             </div>
           )}
-          {errors['serviceData.bookingMethod'] && <p className="text-sm text-red-500 mt-1">{errors['serviceData.bookingMethod']}</p>}
+          {errors['serviceData.bookingMethod'] && (
+            <p className="text-sm text-red-500 mt-1">
+              {errors['serviceData.bookingMethod']}
+            </p>
+          )}
         </CardContent>
       </Card>
 
@@ -107,19 +133,21 @@ const BookingStep: React.FC<StepProps> = ({
         <CardHeader>
           <CardTitle>Pricing Visibility</CardTitle>
           <CardDescription>
-              How do you want to display your pricing?
-                {isFieldOptional(schema!, 'serviceData.pricingVisibility') && (
-                    <span className="text-muted-foreground font-normal text-sm">
-                        {' '}
-                        (optional)
-                    </span>
-                )}
+            How do you want to display your pricing?
+            {isFieldOptional(schema!, 'serviceData.pricingVisibility') && (
+              <span className="text-muted-foreground font-normal text-sm">
+                {' '}
+                (optional)
+              </span>
+            )}
           </CardDescription>
         </CardHeader>
         <CardContent>
           <RadioGroup
             value={pricingVisibility}
-            onValueChange={(value) => handleServiceDataChange('pricingVisibility', value)}
+            onValueChange={value =>
+              handleServiceDataChange('pricingVisibility', value)
+            }
             className="space-y-2"
           >
             <div className="flex items-center space-x-2">
@@ -135,7 +163,32 @@ const BookingStep: React.FC<StepProps> = ({
               <Label htmlFor="quote-price">Quote only</Label>
             </div>
           </RadioGroup>
-          {errors['serviceData.pricingVisibility'] && <p className="text-sm text-red-500 mt-1">{errors['serviceData.pricingVisibility']}</p>}
+          {errors['serviceData.pricingVisibility'] && (
+            <p className="text-sm text-red-500 mt-1">
+              {errors['serviceData.pricingVisibility']}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Insurance</CardTitle>
+          <CardDescription>
+            Confirm if you have public liability insurance.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center space-x-2">
+            <Switch
+              id="hasPublicLiabilityInsurance"
+              checked={hasPublicLiabilityInsurance}
+              onCheckedChange={handleInsuranceToggle}
+            />
+            <Label htmlFor="hasPublicLiabilityInsurance">
+              I have public liability insurance
+            </Label>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/app/dashboard/add-listing/components/steps/shared/BusinessInfoStep.tsx
+++ b/app/dashboard/add-listing/components/steps/shared/BusinessInfoStep.tsx
@@ -163,6 +163,51 @@ const BusinessInfoStep: React.FC<StepProps> = ({
         </FormField>
       </div>
 
+      <FormField
+        id="address"
+        label="Address"
+        tooltip="Your business address. This appears on your listing if you choose to show it."
+        error={errors.address}
+        isOptional={isFieldOptional(validationRules, 'address')}
+      >
+        <Input
+          id="address"
+          value={formData.address || ''}
+          onChange={handleChange}
+          placeholder="123 High Street"
+        />
+      </FormField>
+
+      <FormField
+        id="city"
+        label="City"
+        tooltip="City or town of your business location."
+        error={errors.city}
+        isOptional={isFieldOptional(validationRules, 'city')}
+      >
+        <Input
+          id="city"
+          value={formData.city || ''}
+          onChange={handleChange}
+          placeholder="London"
+        />
+      </FormField>
+
+      <FormField
+        id="postcode"
+        label="Postcode"
+        tooltip="Postcode for your business location."
+        error={errors.postcode}
+        isOptional={isFieldOptional(validationRules, 'postcode')}
+      >
+        <Input
+          id="postcode"
+          value={formData.postcode || ''}
+          onChange={handleChange}
+          placeholder="SW1A 1AA"
+        />
+      </FormField>
+
       <div className="md:col-span-2">
         <FormField
           id="longDesc"

--- a/app/dashboard/add-listing/types.ts
+++ b/app/dashboard/add-listing/types.ts
@@ -16,7 +16,7 @@ export interface Media {
 
 export interface TimeRange {
   start: string;
-  end:string;
+  end: string;
 }
 
 export interface WeeklyHours {
@@ -60,6 +60,7 @@ export interface ProductSellerData {
     ebay?: string;
     etsy?: string;
   };
+  hasAgeRestrictedItems?: boolean;
 }
 
 export interface ServiceProviderData {
@@ -80,6 +81,7 @@ export interface ServiceProviderData {
   pricingVisibility: 'fixed' | 'hourly' | 'quote';
   insuranceCertificates?: Media[];
   qualifications?: Media[];
+  hasPublicLiabilityInsurance?: boolean;
 }
 
 // Main form data structure
@@ -94,6 +96,8 @@ export interface ListingFormData {
   shortDesc: string;
   longDesc?: string;
   address?: string;
+  postcode?: string;
+  city?: string;
   phone: string;
   email: string;
   socials: Socials;


### PR DESCRIPTION
This commit introduces several updates to the listing form, enhancing user input and validation:

- Added new fields for address, city, and postcode in the listing form data structure.
- Implemented validation rules to ensure address, city, and postcode are required.
- Updated the MultiStepListingForm component to handle the new fields and their validation.
- Introduced toggles for age-restricted items and public liability insurance in the SellingModesStep and BookingStep components, respectively.
- Enhanced the BusinessInfoStep to include input fields for address, city, and postcode with appropriate tooltips and error handling.

These changes improve the overall user experience by ensuring necessary information is collected and validated effectively.