### PR TITLE
feat: Change currency symbol to GBP

### DIFF
--- a/app/dashboard/services/page.tsx
+++ b/app/dashboard/services/page.tsx
@@ -233,11 +233,11 @@ export default function ServicesDashboard() {
                           className="mobile-table-cell md:table-cell text-gray-600"
                         >
                           {service.pricingModel === 'fixed' &&
-                            `$${service.fixedPrice}`}
+                            `£${service.fixedPrice}`}
                           {service.pricingModel === 'perHour' &&
-                            `$${service.pricePerHour}/hr`}
+                            `£${service.pricePerHour}/hr`}
                           {service.pricingModel === 'perUnit' &&
-                            `$${service.pricePerUnit}/${service.unitName}`}
+                            `£${service.pricePerUnit}/${service.unitName}`}
                         </TableCell>
                         <TableCell
                           data-label="Date"

--- a/app/dashboard/store/products/page.tsx
+++ b/app/dashboard/store/products/page.tsx
@@ -524,11 +524,11 @@ export default function StoreDashboard() {
                             {product.price !== product.salePrice &&
                               product.salePrice && (
                                 <span className="line-through text-gray-400">
-                                  ${product.price.toFixed(2)}
+                                  £{product.price.toFixed(2)}
                                 </span>
                               )}
                             <span>
-                              ${(product.salePrice || product.price).toFixed(2)}
+                              £{(product.salePrice || product.price).toFixed(2)}
                             </span>
                           </div>
                         </TableCell>


### PR DESCRIPTION
Changed the currency symbol from USD ($) to GBP (£) in the dashboard store and services pages.