### PR TITLE
feat: display customer stats on dashboard

### DIFF
--- a/app/dashboard/component/CustomerDashboard.tsx
+++ b/app/dashboard/component/CustomerDashboard.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { FC } from 'react';
+import {
+  ShoppingCart,
+  Package,
+  BarChart2,
+  MoreHorizontal,
+} from 'lucide-react';
+
+// Import Shadcn UI Components
+import { Card, CardContent } from '@/components/ui/card';
+
+import { useGetCustomerStats } from '@/service/user/hook';
+
+interface StatCardProps {
+  title: string;
+  value: number | string;
+  icon: React.ReactNode;
+  color: string;
+}
+
+const StatCard: FC<StatCardProps> = ({ title, value, icon, color }) => (
+  <Card className="shadow-sm hover:shadow-md transition-shadow duration-300">
+    <CardContent className="p-6 flex items-center justify-between">
+      <div>
+        <p className={`text-3xl font-bold ${color}`}>
+          {typeof value === 'number' ? value.toLocaleString() : value}
+        </p>
+        <p className="text-sm text-gray-500">{title}</p>
+      </div>
+      <div className={color}>{icon}</div>
+    </CardContent>
+  </Card>
+);
+
+const CustomerDashboard: FC = () => {
+  const { data: customerStats, isLoading } = useGetCustomerStats();
+
+  const stats: StatCardProps[] = isLoading
+    ? [
+        {
+          title: 'Total Orders',
+          value: 'loading...',
+          icon: <ShoppingCart className="h-8 w-8" />,
+          color: 'text-green-500',
+        },
+        {
+          title: 'Total Spent',
+          value: 'loading...',
+          icon: <Package className="h-8 w-8" />,
+          color: 'text-blue-500',
+        },
+        {
+          title: 'Promotion Points',
+          value: 'loading...',
+          icon: <BarChart2 className="h-8 w-8" />,
+          color: 'text-yellow-500',
+        },
+        {
+          title: 'Promotions Participating',
+          value: 'loading...',
+          icon: <MoreHorizontal className="h-8 w-8" />,
+          color: 'text-red-500',
+        },
+      ]
+    : [
+        {
+          title: 'Total Orders',
+          value: customerStats?.totalOrders ?? 0,
+          icon: <ShoppingCart className="h-8 w-8" />,
+          color: 'text-green-500',
+        },
+        {
+          title: 'Total Spent',
+          value: `£${customerStats?.totalSpent.toFixed(2) ?? '0.00'}`,
+          icon: <Package className="h-8 w-8" />,
+          color: 'text-blue-500',
+        },
+        {
+          title: 'Promotion Points',
+          value: customerStats?.promotionPoints ?? 0,
+          icon: <BarChart2 className="h-8 w-8" />,
+          color: 'text-yellow-500',
+        },
+        {
+          title: 'Promotions Participating',
+          value: customerStats?.promotionsParticipating ?? 0,
+          icon: <MoreHorizontal className="h-8 w-8" />,
+          color: 'text-red-500',
+        },
+      ];
+  return (
+    <section className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      {stats.map(stat => (
+        <StatCard
+          key={stat.title}
+          title={stat.title}
+          value={stat.value}
+          icon={stat.icon}
+          color={stat.color}
+        />
+      ))}
+    </section>
+  );
+};
+
+export default CustomerDashboard;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,7 +5,6 @@ import {
   PoundSterling,
   ShoppingCart,
   Package,
-  BarChart2,
   MoreHorizontal,
   Diamond,
 } from 'lucide-react';
@@ -42,6 +41,7 @@ import {
 import { formatDistanceToNow } from 'date-fns';
 import { useRecentActivities } from '@/service/activities/hook';
 import { Activity } from '@/service/activities/types';
+import CustomerDashboard from './component/CustomerDashboard';
 // 1. --- TYPE DEFINITIONS ---
 // Ensures all data structures are strongly typed.
 
@@ -209,7 +209,7 @@ const ListingsViewsChart: FC<{ data: ChartData[] }> = ({ data }) => (
 
 const DashboardPage: FC = () => {
   const { data: orderStats, isLoading } = useGetOrderStats();
-  const { userName } = useSelector((state: RootState) => state.auth);
+  const { userName, userRole } = useSelector((state: RootState) => state.auth);
   const {
     data: activities,
     isLoading: isLoadingActivities,
@@ -289,35 +289,41 @@ const DashboardPage: FC = () => {
       </header>
 
       <main className="space-y-8">
-        {/* Stat Cards Section */}
-        <section className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
-          {stats.map(stat => (
-            <StatCard
-              key={stat.title}
-              title={stat.title}
-              value={stat.value}
-              icon={stat.icon}
-              color={stat.color}
-            />
-          ))}
-        </section>
+        {userRole === 'customer' ? (
+          <CustomerDashboard />
+        ) : (
+          <>
+            {/* Stat Cards Section */}
+            <section className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              {stats.map(stat => (
+                <StatCard
+                  key={stat.title}
+                  title={stat.title}
+                  value={stat.value}
+                  icon={stat.icon}
+                  color={stat.color}
+                />
+              ))}
+            </section>
 
-        {/* Main Content Grid */}
-        <section className="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:items-start">
-          {/* Left Column */}
-          <div className="lg:col-span-1 space-y-8">
-            <RecentActivities
-              activities={activities}
-              isLoading={isLoadingActivities}
-            />
-          </div>
+            {/* Main Content Grid */}
+            <section className="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:items-start">
+              {/* Left Column */}
+              <div className="lg:col-span-1 space-y-8">
+                <RecentActivities
+                  activities={activities}
+                  isLoading={isLoadingActivities}
+                />
+              </div>
 
-          {/* Right Column */}
-          <div className="lg:col-span-2 space-y-8">
-            <ListingPackages pkg={listingPackage} />
-            <ListingsViewsChart data={chartData} />
-          </div>
-        </section>
+              {/* Right Column */}
+              <div className="lg:col-span-2 space-y-8">
+                <ListingPackages pkg={listingPackage} />
+                <ListingsViewsChart data={chartData} />
+              </div>
+            </section>
+          </>
+        )}
       </main>
     </div>
   );

--- a/service/user/hook.ts
+++ b/service/user/hook.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import api from '../api';
-import { User, UpdateUserDto } from './types';
+import { User, UpdateUserDto, CustomerStats } from './types';
 
 const USER_QUERY_KEY = 'my-user';
 
@@ -37,5 +37,17 @@ export const useUpdateUserProfile = () => {
       // Invalidate and refetch the user query to get the latest data
       queryClient.invalidateQueries({ queryKey: [USER_QUERY_KEY] });
     },
+  });
+};
+
+const getCustomerStats = async (): Promise<CustomerStats> => {
+  const { data } = await api.get('/stats');
+  return data;
+};
+
+export const useGetCustomerStats = () => {
+  return useQuery({
+    queryKey: ['customerStats'],
+    queryFn: getCustomerStats,
   });
 };

--- a/service/user/types.ts
+++ b/service/user/types.ts
@@ -25,3 +25,10 @@ export interface UpdateUserDto {
   socials?: Partial<Omit<Socials, 'id'>>;
   profilePictureUrl?: string;
 }
+
+export interface CustomerStats {
+  totalOrders: number;
+  totalSpent: number;
+  promotionPoints: number;
+  promotionsParticipating: number;
+}


### PR DESCRIPTION
This commit introduces a new dashboard view for users with the 'customer' role.

The changes include:
- A new `CustomerDashboard` component to display customer-specific statistics.
- A new `useGetCustomerStats` hook to fetch data from the `/stats` API endpoint.
- Conditional rendering logic on the main dashboard page to display the correct view based on the user's role.