### PR TITLE
Refactor: Make External Storefronts dynamic

### DIFF
--- a/app/dashboard/add-listing/components/MultiStepListingForm.tsx
+++ b/app/dashboard/add-listing/components/MultiStepListingForm.tsx
@@ -155,21 +155,6 @@ const validationRules = {
         Object.values(modes).some(v => v),
       message: 'At least one selling mode must be selected.',
     },
-    'productData.storefrontLinks.amazon': {
-      validate: isValidUrl,
-      message: 'Invalid URL.',
-      optional: true,
-    },
-    'productData.storefrontLinks.ebay': {
-      validate: isValidUrl,
-      message: 'Invalid URL.',
-      optional: true,
-    },
-    'productData.storefrontLinks.etsy': {
-      validate: isValidUrl,
-      message: 'Invalid URL.',
-      optional: true,
-    },
   },
   serviceCategory: {
     'serviceData.tradeCategory': {
@@ -263,7 +248,7 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
         },
         fulfilmentNotes: '',
         returnsPolicy: '',
-        storefrontLinks: {},
+        storefrontLinks: [],
       };
     }
     if (businessTypes.includes('Service') && !initialData.serviceData) {
@@ -438,6 +423,22 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
       }
     }
 
+    // Custom validation for storefront links
+    if (formData.productData?.storefrontLinks) {
+      formData.productData.storefrontLinks.forEach((link, index) => {
+        if (link.name && !link.url) {
+          newErrors[`productData.storefrontLinks[${index}].url`] =
+            'URL is required if name is provided.';
+        } else if (link.url && !link.name) {
+          newErrors[`productData.storefrontLinks[${index}].name`] =
+            'Name is required if URL is provided.';
+        } else if (link.url && !isValidUrl(link.url)) {
+          newErrors[`productData.storefrontLinks[${index}].url`] =
+            'Invalid URL format.';
+        }
+      });
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -546,19 +547,25 @@ const MultiStepListingForm: React.FC<MultiStepListingFormProps> = ({
       if (data.productData.sellingModes?.ukWideShipping)
         sellingModes.push('uk_shipping');
 
-      const storefrontLinks: StorefrontLinkPayload[] = Object.entries(
-        data.productData.storefrontLinks || {}
+      const storefrontLinks: StorefrontLinkPayload[] = (
+        data.productData.storefrontLinks || []
       )
-        .map(([platform, url]) => {
-          const formattedUrl = formatUrl(url);
-          return formattedUrl
-            ? {
-                platform: platform as StorefrontLinkPayload['platform'],
-                url: formattedUrl,
-              }
-            : null;
+        .map(link => {
+          if (link.name && link.url) {
+            const formattedUrl = formatUrl(link.url);
+            return formattedUrl
+              ? {
+                  platform: link.name,
+                  url: formattedUrl,
+                }
+              : null;
+          }
+          return null;
         })
-        .filter((link): link is StorefrontLinkPayload => link !== null);
+        .filter(
+          (link): link is StorefrontLinkPayload =>
+            link !== null && link.url !== undefined
+        );
 
       productSellerProfile = {
         sellingModes,

--- a/app/dashboard/add-listing/components/steps/product/SellingModesStep.tsx
+++ b/app/dashboard/add-listing/components/steps/product/SellingModesStep.tsx
@@ -4,6 +4,8 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { PlusCircle, Trash2 } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import {
   Card,
@@ -43,7 +45,7 @@ const SellingModesStep: React.FC<StepProps> = ({
     localDelivery: false,
     ukWideShipping: false,
   };
-  const storefrontLinks = productData.storefrontLinks || {};
+  const storefrontLinks = productData.storefrontLinks || [];
   const hasAgeRestrictedItems = productData.hasAgeRestrictedItems || false;
 
   const handleSellingModeChange = (
@@ -83,19 +85,51 @@ const SellingModesStep: React.FC<StepProps> = ({
   };
 
   const handleStorefrontLinkChange = (
-    e: React.ChangeEvent<HTMLInputElement>
+    index: number,
+    field: 'name' | 'url',
+    value: string
   ) => {
-    const { id, value } = e.target;
+    setFormData(prev => {
+      const newStorefrontLinks = [...(prev.productData?.storefrontLinks || [])];
+      newStorefrontLinks[index] = {
+        ...newStorefrontLinks[index],
+        [field]: value,
+      };
+      return {
+        ...prev,
+        productData: {
+          ...prev.productData,
+          storefrontLinks: newStorefrontLinks,
+        },
+      };
+    });
+  };
+
+  const addStorefrontLink = () => {
     setFormData(prev => ({
       ...prev,
       productData: {
         ...prev.productData,
-        storefrontLinks: {
-          ...(prev.productData?.storefrontLinks || {}),
-          [id]: value,
-        },
+        storefrontLinks: [
+          ...(prev.productData?.storefrontLinks || []),
+          { name: '', url: '' },
+        ],
       },
     }));
+  };
+
+  const removeStorefrontLink = (index: number) => {
+    setFormData(prev => {
+      const newStorefrontLinks = [...(prev.productData?.storefrontLinks || [])];
+      newStorefrontLinks.splice(index, 1);
+      return {
+        ...prev,
+        productData: {
+          ...prev.productData,
+          storefrontLinks: newStorefrontLinks,
+        },
+      };
+    });
   };
 
   const handleToggleAgeRestricted = (checked: boolean) => {
@@ -231,48 +265,60 @@ const SellingModesStep: React.FC<StepProps> = ({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div>
-            <Label htmlFor="amazon">Amazon Store</Label>
-            <Input
-              id="amazon"
-              placeholder="https://amazon.co.uk/your-store"
-              value={storefrontLinks.amazon || ''}
-              onChange={handleStorefrontLinkChange}
-            />
-            {errors['productData.storefrontLinks.amazon'] && (
-              <p className="text-sm text-red-500">
-                {errors['productData.storefrontLinks.amazon']}
-              </p>
-            )}
-          </div>
-          <div>
-            <Label htmlFor="ebay">eBay Store</Label>
-            <Input
-              id="ebay"
-              placeholder="https://ebay.co.uk/usr/your-store"
-              value={storefrontLinks.ebay || ''}
-              onChange={handleStorefrontLinkChange}
-            />
-            {errors['productData.storefrontLinks.ebay'] && (
-              <p className="text-sm text-red-500">
-                {errors['productData.storefrontLinks.ebay']}
-              </p>
-            )}
-          </div>
-          <div>
-            <Label htmlFor="etsy">Etsy Shop</Label>
-            <Input
-              id="etsy"
-              placeholder="https://etsy.com/shop/your-shop"
-              value={storefrontLinks.etsy || ''}
-              onChange={handleStorefrontLinkChange}
-            />
-            {errors['productData.storefrontLinks.etsy'] && (
-              <p className="text-sm text-red-500">
-                {errors['productData.storefrontLinks.etsy']}
-              </p>
-            )}
-          </div>
+          {storefrontLinks.map((link, index) => (
+            <div key={index} className="flex items-end space-x-2">
+              <div className="flex-grow space-y-2">
+                <div>
+                  <Label htmlFor={`storeName-${index}`}>Store Name</Label>
+                  <Input
+                    id={`storeName-${index}`}
+                    placeholder="e.g., My Awesome Shop"
+                    value={link.name}
+                    onChange={e =>
+                      handleStorefrontLinkChange(index, 'name', e.target.value)
+                    }
+                  />
+                  {errors[`productData.storefrontLinks[${index}].name`] && (
+                    <p className="text-sm text-red-500">
+                      {errors[`productData.storefrontLinks[${index}].name`]}
+                    </p>
+                  )}
+                </div>
+                <div>
+                  <Label htmlFor={`storeUrl-${index}`}>Store URL</Label>
+                  <Input
+                    id={`storeUrl-${index}`}
+                    placeholder="https://example.com/store"
+                    value={link.url}
+                    onChange={e =>
+                      handleStorefrontLinkChange(index, 'url', e.target.value)
+                    }
+                  />
+                  {errors[`productData.storefrontLinks[${index}].url`] && (
+                    <p className="text-sm text-red-500">
+                      {errors[`productData.storefrontLinks[${index}].url`]}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => removeStorefrontLink(index)}
+                className="text-red-500 hover:text-red-600"
+              >
+                <Trash2 className="h-5 w-5" />
+              </Button>
+            </div>
+          ))}
+          <Button
+            variant="outline"
+            onClick={addStorefrontLink}
+            className="mt-2"
+          >
+            <PlusCircle className="mr-2 h-4 w-4" />
+            Add Storefront
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/app/dashboard/add-listing/types.ts
+++ b/app/dashboard/add-listing/types.ts
@@ -55,11 +55,7 @@ export interface ProductSellerData {
   };
   fulfilmentNotes?: string;
   returnsPolicy?: string;
-  storefrontLinks?: {
-    amazon?: string;
-    ebay?: string;
-    etsy?: string;
-  };
+  storefrontLinks?: { name: string; url: string }[];
   hasAgeRestrictedItems?: boolean;
 }
 

--- a/app/dashboard/edit-listing/[id]/page.tsx
+++ b/app/dashboard/edit-listing/[id]/page.tsx
@@ -4,10 +4,10 @@ import { useParams, useRouter } from 'next/navigation';
 import { useGetBusinessData } from '@/service/listings/hook';
 import MultiStepListingForm from '@/app/dashboard/add-listing/components/MultiStepListingForm';
 import { ListingFormData } from '@/app/dashboard/add-listing/types';
-import { UserListing } from '@/service/listings/types';
+import { InHouseBusiness } from '@/service/listings/types';
 
 const transformApiDataToFormData = (
-  apiData: UserListing
+  apiData: InHouseBusiness
 ): Partial<ListingFormData> => {
   const formData: Partial<ListingFormData> = {
     businessTypes: apiData.listingType.map(
@@ -44,15 +44,25 @@ const transformApiDataToFormData = (
         type: 'radius',
         value: apiData.location.deliveryRadiusKm?.toString() || '',
       },
-      // Other product fields are not available on UserListing type
       sellingModes: {
-        inStorePickup: false,
-        localDelivery: false,
-        ukWideShipping: false,
+        inStorePickup:
+          apiData.productSellerProfile?.sellingModes.includes('pickup') ||
+          false,
+        localDelivery:
+          apiData.productSellerProfile?.sellingModes.includes(
+            'local_delivery'
+          ) || false,
+        ukWideShipping:
+          apiData.productSellerProfile?.sellingModes.includes('uk_shipping') ||
+          false,
       },
-      fulfilmentNotes: '',
-      returnsPolicy: '',
-      storefrontLinks: {},
+      fulfilmentNotes: apiData.productSellerProfile?.fulfilmentNotes || '',
+      returnsPolicy: apiData.productSellerProfile?.returnsPolicy || '',
+      storefrontLinks:
+        apiData.productSellerProfile?.storefrontLinks.map(link => ({
+          name: link.platform,
+          url: link.url,
+        })) || [],
     };
   }
 


### PR DESCRIPTION
This commit refactors the "External Storefronts" section in the add/edit listing form.

- Replaced the fixed "Amazon", "Ebay", and "Etsy" input fields with a dynamic list.
- Users can now add custom store names and URLs.
- An "Add More" button allows adding multiple storefronts.
- The fields are optional, but if a user adds a storefront, both name and URL are required.
- Updated the validation logic and data transformation to handle the new data structure.
- Ensured that existing listings can be edited with the new structure.