### PR TITLE
feat: Add useGetBusinessGiftCards hook and display gift cards on list…

### DIFF
--- a/app/(public)/listings/[id]/components/GiftCardTabContent.tsx
+++ b/app/(public)/listings/[id]/components/GiftCardTabContent.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useGetBusinessGiftCards } from '@/service/gift-card/hook';
+import { GiftCardTemplate } from '@/service/gift-card/types';
+import { Button } from '@/components/ui/button';
+import Image from 'next/image';
+import { toast } from 'sonner';
+
+interface GiftCardTabContentProps {
+  businessId: string;
+}
+
+export default function GiftCardTabContent({ businessId }: GiftCardTabContentProps) {
+  const { data: templates, isPending, isError } = useGetBusinessGiftCards(businessId);
+
+  if (isPending) {
+    return <p>Loading gift cards...</p>;
+  }
+
+  if (isError) {
+    return <p>There was an error fetching gift cards.</p>;
+  }
+
+  if (!templates || templates.length === 0) {
+    return <p>No gift cards available for this business.</p>;
+  }
+
+  const handleBuyNow = (template: GiftCardTemplate) => {
+    toast.info(`The "Buy Now" functionality for "${template.name}" is not yet implemented.`);
+  };
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      {templates.map((template) => (
+        <div key={template.id} className="bg-white rounded-lg shadow-md overflow-hidden transform transition-transform hover:scale-105">
+          <div className="relative h-48 w-full">
+            <Image
+              src={template.imageUrl || 'https://via.placeholder.com/400x200'}
+              alt={template.name}
+              layout="fill"
+              objectFit="cover"
+            />
+          </div>
+          <div className="p-4">
+            <h3 className="text-lg font-bold text-gray-900">{template.name}</h3>
+            <p className="text-sm text-gray-600 mt-1">{template.description}</p>
+            <div className="mt-4">
+              <h4 className="text-sm font-semibold text-gray-700">Available Amounts:</h4>
+              <div className="flex flex-wrap gap-2 mt-2">
+                {template.fixedAmounts.map((amount) => (
+                  <span key={amount} className="px-3 py-1 bg-gray-200 text-gray-800 rounded-full text-sm">
+                    £{amount}
+                  </span>
+                ))}
+                {template.allowCustomAmount && (
+                  <span className="px-3 py-1 bg-green-100 text-green-800 rounded-full text-sm">
+                    Custom ( £{template.minCustomAmount} - £{template.maxCustomAmount} )
+                  </span>
+                )}
+              </div>
+            </div>
+            <Button
+              className="w-full mt-6 bg-orange-600 hover:bg-orange-700 text-white"
+              onClick={() => handleBuyNow(template)}
+            >
+              Buy Now
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/ContentTabs.tsx
+++ b/components/ContentTabs.tsx
@@ -41,6 +41,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import LoyaltyContent from './LoyaltyContent';
+import GiftCardTabContent from '@/app/(public)/listings/[id]/components/GiftCardTabContent';
 
 function ProductPage({
   listing,
@@ -532,7 +533,11 @@ function AboutBusinessTabs({
         <p>Voucher content goes here.</p>
       </TabsContent>
       <TabsContent value="gift-card">
-        <p>Gift Card content goes here.</p>
+        {businessId ? (
+          <GiftCardTabContent businessId={businessId} />
+        ) : (
+          <p>Gift cards are not available for this listing.</p>
+        )}
       </TabsContent>
     </Tabs>
   );

--- a/service/gift-card/hook.ts
+++ b/service/gift-card/hook.ts
@@ -22,6 +22,19 @@ export const useGetGiftCardTemplates = () => {
   });
 };
 
+const fetchBusinessGiftCardTemplates = async (businessId: string): Promise<GiftCardTemplate[]> => {
+  const { data } = await api.get<GiftCardTemplate[]>(`/gift-cards/templates/${businessId}`);
+  return data;
+};
+
+export const useGetBusinessGiftCards = (businessId: string) => {
+  return useQuery<GiftCardTemplate[], Error>({
+    queryKey: ['businessGiftCardTemplates', businessId],
+    queryFn: () => fetchBusinessGiftCardTemplates(businessId),
+    enabled: !!businessId,
+  });
+};
+
 export const useAddGiftCardTemplate = () => {
     const queryClient = useQueryClient();
     return useMutation<GiftCardTemplate, Error, CreateGiftCardTemplateDto>({


### PR DESCRIPTION
…ing page

This commit introduces a new custom hook, `useGetBusinessGiftCards`, to fetch gift card templates for a specific business. It also adds a new component, `GiftCardTabContent`, to display the fetched gift cards in a professional and responsive layout on the listing details page.

- Created the `useGetBusinessGiftCards` hook in `service/gift-card/hook.ts` to fetch data from the `gift-cards/templates/:businessId` endpoint.
- Developed the `GiftCardTabContent` component in `app/(public)/listings/[id]/components/` to render the gift cards with their details, including name, image, price options, and a 'Buy Now' button.
- Integrated the `GiftCardTabContent` component into `components/ContentTabs.tsx` to display the gift cards under the 'Gift Card' tab.