### PR TITLE
fix: Convert voucher currency strings to numbers

### DIFF
--- a/app/dashboard/history/my-vouchers/page.tsx
+++ b/app/dashboard/history/my-vouchers/page.tsx
@@ -46,11 +46,11 @@ const MyVoucherRow: React.FC<MyVoucherRowProps> = ({ voucher }) => {
       </td>
       <td className="whitespace-nowrap px-6 py-4 text-sm text-slate-600">
         {CURRENCY}
-        {parseFloat(voucher.initialValue).toFixed(2)}
+        {Number(voucher.initialValue).toFixed(2)}
       </td>
       <td className="whitespace-nowrap px-6 py-4 text-sm text-slate-600">
         {CURRENCY}
-        {parseFloat(voucher.balance).toFixed(2)}
+        {Number(voucher.balance).toFixed(2)}
       </td>
       <td className="whitespace-nowrap px-6 py-4 text-sm">
         <span


### PR DESCRIPTION
Converts `voucher.initialValue` and `voucher.balance` from strings to numbers before calling `toFixed()` to prevent a `TypeError` on the my-vouchers page.