### PR TITLE
Remove top nav from dashboard and disable QR scanner menu item

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -95,9 +95,9 @@ export default function DashboardLayout({
             </div>
 
             {/* --- CENTER: DESKTOP NAV MENU --- */}
-            <div className="flex-grow flex justify-center">
+            {/* <div className="flex-grow flex justify-center">
               <NavMenu />
-            </div>
+            </div> */}
 
             {/* --- RIGHT SIDE: User Avatar & Mobile Nav Trigger --- */}
             <div className="flex items-center gap-4">

--- a/lib/menu-items.ts
+++ b/lib/menu-items.ts
@@ -48,7 +48,7 @@ export const mainMenuItems: MenuItem[] = [
   { title: 'My Bookings', href: '/dashboard/my-bookings', icon: Calendar },
   { title: 'Messages', href: '/dashboard/messages', icon: MessageSquare },
   { title: 'My Wishlist', href: '/dashboard/wishlist', icon: Heart },
-  { title: 'QR Scanner', href: '/dashboard/bookings/qr-scanner', icon: QrCode },
+  // { title: 'QR Scanner', href: '/dashboard/bookings/qr-scanner', icon: QrCode },
   // { title: 'Store', href: '/dashboard/store', icon: LayoutDashboard },
 ];
 


### PR DESCRIPTION
- Removed `NavMenu` from `app/dashboard/layout.tsx` to hide global navigation links in the dashboard.
- Commented out "QR Scanner" in `lib/menu-items.ts` to hide it from the dashboard sidebar.