### PR TITLE
Make Activity Timer Configurable

### DIFF
--- a/app/dashboard/activity-timer/page.tsx
+++ b/app/dashboard/activity-timer/page.tsx
@@ -106,7 +106,7 @@ const ActivityTimerPage: FC = () => {
 
   const taskKeys = Object.keys(tasks) as (keyof TrialTasks)[];
 
-  const taskDetails: Record<
+  const defaultTaskDetails: Record<
     keyof TrialTasks,
     { title: string; description: string; url: string }
   > = {
@@ -137,6 +137,11 @@ const ActivityTimerPage: FC = () => {
       url: "/dashboard/messages",
     },
   };
+
+  const taskDetails = {
+    ...defaultTaskDetails,
+    ...(trialStatus.taskDetails || {}),
+  } as Record<keyof TrialTasks, { title: string; description: string; url: string }>;
 
   return (
     <div className="min-h-[calc(100vh-8rem)] bg-white text-black p-4 sm:p-6 md:p-8">

--- a/service/payments/hook.ts
+++ b/service/payments/hook.ts
@@ -47,12 +47,12 @@ export const useGetTrialStatus = () => {
       }
 
       // Derive UI-related fields from the core API response
-      const maxPauses = 2;
+      const maxPauses = data.maxPauses ?? 2;
       const pausesCount = data.pauses?.length || 0;
       const lastPause = pausesCount > 0 ? data.pauses[pausesCount - 1] : null;
 
       const isPaused = !!lastPause && lastPause.resumedAt === null;
-      const remainingPauses = maxPauses - pausesCount;
+      const remainingPauses = Math.max(0, maxPauses - pausesCount);
       const isTrialPausable = remainingPauses > 0;
 
       return {

--- a/service/payments/types.ts
+++ b/service/payments/types.ts
@@ -116,6 +116,9 @@ export interface TrialStatusResponse {
   remainingTime: number;
   tasks: TrialTasks;
   pauses: TrialPause[];
+  // Dynamic configuration from admin
+  maxPauses?: number;
+  taskDetails?: Record<string, { title: string; description: string; url: string }>;
   // The following fields are derived in the hook for UI convenience
   isPaused?: boolean;
   isTrialPausable?: boolean;


### PR DESCRIPTION
This change prepares the seller dashboard's Activity Timer page to be fully configurable from an admin interface. It moves hardcoded values (like max pauses and task descriptions) into a dynamic structure that can be controlled by the backend.

---
*PR created automatically by Jules for task [13420930715678361777](https://jules.google.com/task/13420930715678361777) started by @Jahzeal*