### PR TITLE
Resolve ZodError by adding business selection to Add Service Step 1

### DIFF
--- a/app/dashboard/services/add-service/components/Step1BasicInfo.tsx
+++ b/app/dashboard/services/add-service/components/Step1BasicInfo.tsx
@@ -28,8 +28,17 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { cn } from '@/lib/utils';
 import { useGetCategories, useGetSubCategoriesByCategory } from '@/service/taxonomy/hook';
+import { useGetUserListings } from '@/service/listings/hook';
+import { toast } from 'sonner';
 import {
   Tooltip,
   TooltipContent,
@@ -51,6 +60,21 @@ export function Step1BasicInfo() {
 
   const { data: categories } = useGetCategories();
   const { data: subCategories } = useGetSubCategoriesByCategory(selectedCategory);
+  const { data: listings, isLoading: isLoadingListings } = useGetUserListings(1, 100);
+
+  const businesses = React.useMemo(() => {
+    if (!listings?.data) return [];
+    return listings.data.filter((l: any) =>
+      l.id && l.id.trim() !== '' &&
+      l.listingType?.some((type: string) => type.toLowerCase() === 'service')
+    );
+  }, [listings]);
+
+  React.useEffect(() => {
+    if (!isLoadingListings && businesses.length === 0) {
+      toast.error("No service businesses found. Please create a 'Service' business listing first in 'My Listings'.");
+    }
+  }, [isLoadingListings, businesses.length]);
 
   const [audienceOpen, setAudienceOpen] = useState(false);
   const [tagsOpen, setTagsOpen] = useState(false);
@@ -85,6 +109,56 @@ export function Step1BasicInfo() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
+          {/* Business Selection */}
+          <FormField
+            control={form.control}
+            name="businessId"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-center gap-2 mb-2">
+                  <FormLabel className="text-base font-semibold">
+                    Business <span className="text-red-500">*</span>
+                  </FormLabel>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <HelpCircle className="w-4 h-4 text-muted-foreground cursor-help" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Select which business will offer this service.
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value}
+                  disabled={isLoadingListings}
+                >
+                  <FormControl>
+                    <SelectTrigger className="py-6">
+                      <SelectValue
+                        placeholder={isLoadingListings ? 'Loading businesses...' : 'Select Business'}
+                      />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {businesses.length > 0 ? (
+                      businesses.map((b: any) => (
+                        <SelectItem key={b.id} value={b.id}>
+                          {b.businessName}
+                        </SelectItem>
+                      ))
+                    ) : (
+                      <div className="p-2 text-sm text-muted-foreground text-center">
+                        No service businesses available
+                      </div>
+                    )}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
           {/* Service Name */}
           <FormField
             control={form.control}

--- a/app/dashboard/services/add-service/components/Step1BasicInfo.tsx
+++ b/app/dashboard/services/add-service/components/Step1BasicInfo.tsx
@@ -46,6 +46,10 @@ import {
 } from '@/components/ui/tooltip';
 import { Badge } from '@/components/ui/badge';
 
+interface Step1Props {
+  userListings?: any[];
+}
+
 const AUDIENCE_OPTIONS = [
   "Families", "Seniors", "Students", "Professionals", "Couples", "Children", "Business Owners", "Everyone"
 ];
@@ -54,27 +58,12 @@ const COMMON_TAGS = [
   "Reliable", "Fast", "Affordable", "Premium", "Eco-friendly", "Expert", "Licensed", "Insured", "24/7 Service"
 ];
 
-export function Step1BasicInfo() {
+export function Step1BasicInfo({ userListings = [] }: Step1Props) {
   const form = useFormContext();
   const selectedCategory = form.watch('category');
 
   const { data: categories } = useGetCategories();
   const { data: subCategories } = useGetSubCategoriesByCategory(selectedCategory);
-  const { data: listings, isLoading: isLoadingListings } = useGetUserListings(1, 100);
-
-  const businesses = React.useMemo(() => {
-    if (!listings?.data) return [];
-    return listings.data.filter((l: any) =>
-      l.id && l.id.trim() !== '' &&
-      l.listingType?.some((type: string) => type.toLowerCase() === 'service')
-    );
-  }, [listings]);
-
-  React.useEffect(() => {
-    if (!isLoadingListings && businesses.length === 0) {
-      toast.error("No service businesses found. Please create a 'Service' business listing first in 'My Listings'.");
-    }
-  }, [isLoadingListings, businesses.length]);
 
   const [audienceOpen, setAudienceOpen] = useState(false);
   const [tagsOpen, setTagsOpen] = useState(false);
@@ -131,18 +120,17 @@ export function Step1BasicInfo() {
                 <Select
                   onValueChange={field.onChange}
                   value={field.value}
-                  disabled={isLoadingListings}
                 >
                   <FormControl>
                     <SelectTrigger className="py-6">
                       <SelectValue
-                        placeholder={isLoadingListings ? 'Loading businesses...' : 'Select Business'}
+                        placeholder="Select Business"
                       />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {businesses.length > 0 ? (
-                      businesses.map((b: any) => (
+                    {userListings.length > 0 ? (
+                      userListings.map((b: any) => (
                         <SelectItem key={b.id} value={b.id}>
                           {b.businessName}
                         </SelectItem>

--- a/app/dashboard/services/add-service/page.tsx
+++ b/app/dashboard/services/add-service/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -16,6 +16,7 @@ import { CreateServiceDto } from '@/service/services/types';
 import { uploadFile } from '@/lib/upload';
 import { SuccessAnimationDialog } from '@/components/SuccessAnimationDialog';
 import { useGetCategories, useGetSubCategoriesByCategory } from '@/service/taxonomy/hook';
+import { useGetUserListings } from '@/service/listings/hook';
 
 import { Step1BasicInfo } from './components/Step1BasicInfo';
 import { Step2ServiceType } from './components/Step2ServiceType';
@@ -171,6 +172,15 @@ export default function AddServicePage() {
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
 
   const { mutate: addService, isPending: isAddingService } = useAddService();
+  const { data: listings } = useGetUserListings(1, 100);
+
+  const businesses = useMemo(() => {
+    if (!listings?.data) return [];
+    return listings.data.filter((l: any) =>
+      l.id && l.id.trim() !== '' &&
+      l.listingType?.some((type: string) => type.toLowerCase() === 'service')
+    );
+  }, [listings]);
 
   const form = useForm<ServiceFormValues>({
     resolver: zodResolver(serviceSchema),
@@ -240,6 +250,12 @@ export default function AddServicePage() {
       ],
     },
   });
+
+  useEffect(() => {
+    if (businesses.length === 1 && !form.getValues('businessId')) {
+      form.setValue('businessId', businesses[0].id);
+    }
+  }, [businesses, form]);
 
   const { data: categories } = useGetCategories();
   const categoryId = form.watch('category');
@@ -316,7 +332,7 @@ export default function AddServicePage() {
     const values = form.getValues();
 
     if (currentStep === 1) {
-      isValid = !!values.name && !!values.category;
+      isValid = !!values.name && !!values.category && !!values.businessId;
     } else if (currentStep === 2) {
       isValid = !!values.deliveryConfig?.mode;
     } else if (currentStep === 3) {
@@ -343,7 +359,7 @@ export default function AddServicePage() {
     } else {
       // Trigger validation to show error messages in the UI
       const fieldsToValidate: any = {
-        1: ['name', 'category'],
+        1: ['name', 'category', 'businessId'],
         2: ['deliveryConfig.mode'],
         3: ['pricingModel', 'fixedPrice', 'pricePerHour', 'pricePerUnit'],
         6: ['businessId', 'media'],

--- a/app/dashboard/services/add-service/page.tsx
+++ b/app/dashboard/services/add-service/page.tsx
@@ -172,7 +172,7 @@ export default function AddServicePage() {
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
 
   const { mutate: addService, isPending: isAddingService } = useAddService();
-  const { data: listings } = useGetUserListings(1, 100);
+  const { data: listings } = useGetUserListings();
 
   const businesses = useMemo(() => {
     if (!listings?.data) return [];
@@ -442,7 +442,7 @@ export default function AddServicePage() {
               className="space-y-8"
             >
               <div className="min-h-[400px]">
-                {currentStep === 1 && <Step1BasicInfo />}
+                {currentStep === 1 && <Step1BasicInfo userListings={businesses} />}
                 {currentStep === 2 && <Step2ServiceType />}
                 {currentStep === 3 && <Step3Pricing />}
                 {currentStep === 4 && <Step4Availability />}


### PR DESCRIPTION
This PR resolves a reported `ZodError` ("Please select a business") in the 'Add Service' flow. 

The issue was caused by `businessId` being a required field in the Zod schema but only being selectable in the final step (Step 6) of the wizard, leading to validation failures if the user tried to proceed or if the form was triggered earlier.

Key changes:
1. **Auto-population:** The main `AddServicePage` now fetches user listings and automatically sets the `businessId` if the user has exactly one business listing of type 'service'.
2. **Step 1 Integration:** A business selection dropdown has been added to the first step of the wizard, allowing users to select or verify the business early in the process. This aligns the 'Add Service' flow with the 'Add Product' flow.
3. **Improved Validation:** The wizard's navigation logic (`nextStep`) now includes `businessId` in the Step 1 validation fields, preventing users from moving forward without a valid business selection.
4. **Resiliency:** Added optional chaining to `listingType` checks to prevent potential runtime errors if the field is missing.

These changes ensure that `businessId` is always present before the final submission, resolving the `ZodError` and improving the overall user experience.

---
*PR created automatically by Jules for task [17828997803031005778](https://jules.google.com/task/17828997803031005778) started by @Jahzeal*