### PR TITLE
Fix businessId validation error in Add Product/Service flows

### DIFF
--- a/app/dashboard/services/add-service/components/Step6FinalReview.tsx
+++ b/app/dashboard/services/add-service/components/Step6FinalReview.tsx
@@ -21,7 +21,6 @@ import {
 import { Store, Image as ImageIcon, CheckCircle2, HelpCircle } from 'lucide-react';
 import MultiMediaUpload from '@/app/dashboard/add-listing/components/steps/shared/MultiMediaUpload';
 import { UserListing } from '@/service/listings/types';
-import { useGetUserListings } from '@/service/listings/hook';
 import { toast } from 'sonner';
 import {
   Tooltip,
@@ -29,17 +28,13 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-export function Step6FinalReview() {
-  const { control, watch } = useFormContext();
-  const { data: listings, isLoading: isLoadingListings } = useGetUserListings(1, 100);
+interface Step6FinalReviewProps {
+  businesses: UserListing[];
+  isLoadingListings: boolean;
+}
 
-  const businesses = React.useMemo(() => {
-    if (!listings?.data) return [];
-    return listings.data.filter((l: UserListing) =>
-      l.id && l.id.trim() !== '' &&
-      l.listingType.some(type => type.toLowerCase() === 'service')
-    );
-  }, [listings]);
+export function Step6FinalReview({ businesses, isLoadingListings }: Step6FinalReviewProps) {
+  const { control, watch } = useFormContext();
 
   React.useEffect(() => {
     if (!isLoadingListings && businesses.length === 0) {

--- a/app/dashboard/services/add-service/page.tsx
+++ b/app/dashboard/services/add-service/page.tsx
@@ -16,6 +16,8 @@ import { CreateServiceDto } from '@/service/services/types';
 import { uploadFile } from '@/lib/upload';
 import { SuccessAnimationDialog } from '@/components/SuccessAnimationDialog';
 import { useGetCategories, useGetSubCategoriesByCategory } from '@/service/taxonomy/hook';
+import { useGetUserListings } from '@/service/listings/hook';
+import { UserListing } from '@/service/listings/types';
 
 import { Step1BasicInfo } from './components/Step1BasicInfo';
 import { Step2ServiceType } from './components/Step2ServiceType';
@@ -171,6 +173,15 @@ export default function AddServicePage() {
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
 
   const { mutate: addService, isPending: isAddingService } = useAddService();
+  const { data: listings, isLoading: isLoadingListings } = useGetUserListings(1, 100);
+
+  const businesses = React.useMemo(() => {
+    if (!listings?.data) return [];
+    return listings.data.filter((l: UserListing) =>
+      l.id && l.id.trim() !== '' &&
+      l.listingType.some(type => type.toLowerCase() === 'service')
+    );
+  }, [listings]);
 
   const form = useForm<ServiceFormValues>({
     resolver: zodResolver(serviceSchema),
@@ -244,6 +255,12 @@ export default function AddServicePage() {
   const { data: categories } = useGetCategories();
   const categoryId = form.watch('category');
   const { data: subcategories } = useGetSubCategoriesByCategory(categoryId);
+
+  React.useEffect(() => {
+    if (!isLoadingListings && businesses.length === 1 && !form.getValues('businessId')) {
+      form.setValue('businessId', businesses[0].id);
+    }
+  }, [isLoadingListings, businesses, form]);
 
   const onSubmit = async (data: ServiceFormValues) => {
     try {
@@ -431,7 +448,12 @@ export default function AddServicePage() {
                 {currentStep === 3 && <Step3Pricing />}
                 {currentStep === 4 && <Step4Availability />}
                 {currentStep === 5 && <Step5Workflow />}
-                {currentStep === 6 && <Step6FinalReview />}
+                {currentStep === 6 && (
+                  <Step6FinalReview
+                    businesses={businesses}
+                    isLoadingListings={isLoadingListings}
+                  />
+                )}
               </div>
 
               <div className="flex justify-between pt-8 border-t">

--- a/app/dashboard/store/products/add-product/page.tsx
+++ b/app/dashboard/store/products/add-product/page.tsx
@@ -24,8 +24,14 @@ import { useRouter } from 'next/navigation';
 export default function AddProductPage() {
   const router = useRouter();
   const { user } = useAuth();
-  const { data: userListings } = useGetUserListings();
+  const { data: userListings, isLoading: isLoadingListings } = useGetUserListings(1, 100);
   const { mutate: addProduct, isPending } = useAddProduct();
+
+  const businesses = React.useMemo(() => {
+    return userListings?.data?.filter((l: any) =>
+      l.listingType?.some((t: string) => t.toLowerCase() === 'product')
+    ) || [];
+  }, [userListings]);
 
   const [step, setStep] = useState(1);
   const [isPublished, setIsPublished] = useState(false);
@@ -91,10 +97,10 @@ export default function AddProductPage() {
   };
 
   useEffect(() => {
-    if (userListings?.data?.length === 1 && !formData.bussinessId) {
-      updateFormData({ bussinessId: userListings.data[0].id });
+    if (!isLoadingListings && businesses.length === 1 && !formData.bussinessId) {
+      updateFormData({ bussinessId: businesses[0].id });
     }
-  }, [userListings, formData.bussinessId]);
+  }, [isLoadingListings, businesses, formData.bussinessId]);
 
 
   const handlePublish = () => {
@@ -204,6 +210,7 @@ export default function AddProductPage() {
   };
 
   const nextStep = () => {
+    window.scrollTo(0, 0);
     // Branching from Step 3
     if (step === 3) {
       if (formData.product_type !== 'physical') {
@@ -268,6 +275,7 @@ export default function AddProductPage() {
   };
 
   const prevStep = () => {
+    window.scrollTo(0, 0);
     if (step === 8) {
       if (formData.product_type !== 'physical') return setStep(3);
       if (fulfillmentType.includes('pickup')) return setStep(5.1);
@@ -299,7 +307,7 @@ export default function AddProductPage() {
   const renderStep = () => {
     switch (step) {
       case 1:
-        return <Step1BasicInfo formData={formData} updateFormData={updateFormData} onNext={nextStep} onCancel={() => { }} userListings={userListings?.data || []} />;
+        return <Step1BasicInfo formData={formData} updateFormData={updateFormData} onNext={nextStep} onCancel={() => { }} userListings={businesses} />;
       case 2:
         return <Step2MediaContent formData={formData} updateFormData={updateFormData} onNext={nextStep} onBack={prevStep} onSaveDraft={() => { }} />;
       case 3:


### PR DESCRIPTION
This change addresses the ZodError: [ { "origin": "string", "code": "too_small", "minimum": 1, "inclusive": true, "path": [ "businessId" ], "message": "Please select a business" } ] encountered during the product/service creation process.

Key improvements:
1. **Add Service Flow**: Lifted `useGetUserListings` to the page level. Added a `useEffect` to automatically set `businessId` if the user has only one 'service' business, preventing the validation error for single-business users.
2. **Step6FinalReview**: Refactored to receive business data via props, improving performance and reliability.
3. **Add Product Flow**: Standardized the auto-selection logic to use a limit of 100 listings and explicit 'product' type filtering. Added page reset (scroll to top) on step transitions.
4. **Data Integrity**: Used optional chaining and case-insensitive comparison when filtering `listingType` to ensure robust business identification.

---
*PR created automatically by Jules for task [6571896588075134161](https://jules.google.com/task/6571896588075134161) started by @Jahzeal*