### PR TITLE
Improve business selection in Add Product flow

### DIFF
--- a/app/dashboard/store/products/add-product/page.tsx
+++ b/app/dashboard/store/products/add-product/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import Step1BasicInfo from '../components/wizard/Step1BasicInfo';
 import Step2MediaContent from '../components/wizard/Step2MediaContent';
 import Step3PricingInventory from '../components/wizard/Step3PricingInventory';
@@ -16,16 +16,24 @@ import Step8Finalize from '../components/wizard/Step8Finalize';
 import { ProductStatusModal } from '../components/wizard/lib/ProductStatusModal';
 import { useAuth } from '@/service/auth/hook';
 import { useGetUserListings } from '@/service/listings/hook';
+import { UserListing } from '@/service/listings/types';
 import { useAddProduct } from '@/service/store/products/hook';
-import { useEffect } from 'react';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 
 export default function AddProductPage() {
   const router = useRouter();
   const { user } = useAuth();
-  const { data: userListings } = useGetUserListings();
+  const { data: userListings } = useGetUserListings(1, 100);
   const { mutate: addProduct, isPending } = useAddProduct();
+
+  const businesses = useMemo(() => {
+    if (!userListings?.data) return [];
+    return userListings.data.filter((l: UserListing) =>
+      l.id && l.id.trim() !== '' &&
+      l.listingType?.some(type => type.toLowerCase() === 'product')
+    );
+  }, [userListings]);
 
   const [step, setStep] = useState(1);
   const [isPublished, setIsPublished] = useState(false);
@@ -91,10 +99,10 @@ export default function AddProductPage() {
   };
 
   useEffect(() => {
-    if (userListings?.data?.length === 1 && !formData.bussinessId) {
-      updateFormData({ bussinessId: userListings.data[0].id });
+    if (businesses.length === 1 && !formData.bussinessId) {
+      updateFormData({ bussinessId: businesses[0].id });
     }
-  }, [userListings, formData.bussinessId]);
+  }, [businesses, formData.bussinessId, updateFormData]);
 
 
   const handlePublish = () => {
@@ -299,7 +307,7 @@ export default function AddProductPage() {
   const renderStep = () => {
     switch (step) {
       case 1:
-        return <Step1BasicInfo formData={formData} updateFormData={updateFormData} onNext={nextStep} onCancel={() => { }} userListings={userListings?.data || []} />;
+        return <Step1BasicInfo formData={formData} updateFormData={updateFormData} onNext={nextStep} onCancel={() => { }} userListings={businesses} />;
       case 2:
         return <Step2MediaContent formData={formData} updateFormData={updateFormData} onNext={nextStep} onBack={prevStep} onSaveDraft={() => { }} />;
       case 3:

--- a/app/dashboard/store/products/components/wizard/Step1BasicInfo.tsx
+++ b/app/dashboard/store/products/components/wizard/Step1BasicInfo.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { UserListing } from '@/service/listings/types';
 import { useGetCategories, useGetSubCategoriesByCategory } from '@/service/taxonomy/hook';
 import {
   ChevronDown,
@@ -23,7 +24,7 @@ interface Step1Props {
   updateFormData: (data: any) => void;
   onNext: () => void;
   onCancel: () => void;
-  userListings?: any[];
+  userListings?: UserListing[];
 }
 
 export default function Step1BasicInfo({ formData, updateFormData, onNext, onCancel, userListings }: Step1Props) {
@@ -86,11 +87,13 @@ export default function Step1BasicInfo({ formData, updateFormData, onNext, onCan
                   onChange={handleChange}
                 >
                   <option disabled value="">Select a business...</option>
-                  {userListings?.map((listing: any) => (
-                    <option key={listing.id} value={listing.id}>
-                      {listing.businessName}
-                    </option>
-                  ))}
+                  {userListings
+                    ?.filter(listing => listing.id && listing.id.trim() !== '')
+                    ?.map((listing) => (
+                      <option key={listing.id} value={listing.id}>
+                        {listing.businessName}
+                      </option>
+                    ))}
                 </select>
                 <div className="absolute inset-y-0 right-0 flex items-center px-3 pointer-events-none text-[#9c7349]">
                   <ChevronDown className="w-5 h-5" />


### PR DESCRIPTION
This change improves the business selection dropdown in the 'Add Product' flow. 

Key changes:
1.  **Endpoint Investigation**: Confirmed that businesses are fetched via the `useGetUserListings` hook which calls the `/listings/mine` endpoint.
2.  **Pagination Improvement**: Increased the fetching limit from the default 10 to 100 in `AddProductPage.tsx` to handle users with many listings.
3.  **Contextual Filtering**: Implemented client-side filtering to ensure that only listings with the 'product' type are available for product creation, avoiding confusion with service-only businesses.
4.  **UX Enhancement**: Added logic to automatically select the business if a user has exactly one eligible business listing.
5.  **Robustness**: Added a filter in `Step1BasicInfo.tsx` to exclude listings with empty or whitespace-only IDs, preventing potential UI crashes.
6.  **Code Quality**: Refined imports and hook dependencies based on code review feedback.

---
*PR created automatically by Jules for task [11293352530175033556](https://jules.google.com/task/11293352530175033556) started by @Jahzeal*