### PR TITLE
Implement pending review status and admin approval workflow

### DIFF
--- a/apps/mcom_mallAPI/src/resources/reviews/dto/create-review.dto.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/dto/create-review.dto.ts
@@ -1,14 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsString, Max, Min } from 'class-validator';
 
 export class CreateReviewDto {
+  @ApiProperty({
+    example: 5,
+    description: 'Rating from 1 to 5',
+    minimum: 1,
+    maximum: 5,
+  })
   @IsInt()
   @Min(1)
   @Max(5)
   rating: number;
 
+  @ApiProperty({
+    example: 'Great service!',
+    description: 'Review comment',
+  })
   @IsString()
   comment: string;
 
+  @ApiProperty({
+    example: 'uuid-string',
+    description: 'ID of the business being reviewed',
+  })
   @IsString()
   businessId: string;
 }

--- a/apps/mcom_mallAPI/src/resources/reviews/entities/review.entity.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/entities/review.entity.ts
@@ -10,6 +10,11 @@ import {
 import { User } from '../../users/entities/user.entity';
 import { Business } from '../../listings/entities/listing.entity';
 
+export enum ReviewStatus {
+  PENDING = 'pending',
+  PUBLISHED = 'published',
+}
+
 @Entity('reviews')
 export class Review {
   @PrimaryGeneratedColumn('uuid')
@@ -20,6 +25,13 @@ export class Review {
 
   @Column({ type: 'text' })
   comment: string;
+
+  @Column({
+    type: 'enum',
+    enum: ReviewStatus,
+    default: ReviewStatus.PENDING,
+  })
+  status: ReviewStatus;
 
   @ManyToOne(() => User, (user) => user.reviews)
   @JoinColumn({ name: 'user_id' })

--- a/apps/mcom_mallAPI/src/resources/reviews/entities/review.entity.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/entities/review.entity.ts
@@ -9,6 +9,7 @@ import {
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
 import { Business } from '../../listings/entities/listing.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 export enum ReviewStatus {
   PENDING = 'pending',
@@ -17,15 +18,19 @@ export enum ReviewStatus {
 
 @Entity('reviews')
 export class Review {
+  @ApiProperty({ example: 'uuid-string', description: 'Unique identifier' })
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @ApiProperty({ example: 5, description: 'Rating value' })
   @Column({ type: 'int' })
   rating: number;
 
+  @ApiProperty({ example: 'Excellent service!', description: 'Review comment' })
   @Column({ type: 'text' })
   comment: string;
 
+  @ApiProperty({ enum: ReviewStatus, example: ReviewStatus.PENDING })
   @Column({
     type: 'enum',
     enum: ReviewStatus,
@@ -33,17 +38,21 @@ export class Review {
   })
   status: ReviewStatus;
 
+  @ApiProperty({ type: () => User })
   @ManyToOne(() => User, (user) => user.reviews)
   @JoinColumn({ name: 'user_id' })
   user: User;
 
+  @ApiProperty({ type: () => Business })
   @ManyToOne(() => Business, (business) => business.reviews)
   @JoinColumn({ name: 'business_id' })
   business: Business;
 
+  @ApiProperty()
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
+  @ApiProperty()
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
 }

--- a/apps/mcom_mallAPI/src/resources/reviews/reviews.controller.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/reviews.controller.ts
@@ -10,6 +10,13 @@ import {
   Request,
   Query,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
@@ -20,43 +27,37 @@ import { Roles } from '../../common/decorators/roles.decorator';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { UserRole } from '../../common/role.enum';
 import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
-import { ReviewStatus } from './entities/review.entity';
+import { Review, ReviewStatus } from './entities/review.entity';
+import { PageDto } from '../../common/dto/page.dto';
 
+@ApiTags('reviews')
 @Controller('reviews')
 export class ReviewsController {
   constructor(private readonly reviewsService: ReviewsService) {}
 
   @Post()
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Create a new review' })
+  @ApiResponse({ status: 201, description: 'Review successfully created.', type: Review })
   create(@Body() createReviewDto: CreateReviewDto, @Request() req) {
     return this.reviewsService.create(createReviewDto, req.user);
   }
 
   @Get()
+  @ApiOperation({ summary: 'Get all reviews' })
+  @ApiResponse({ status: 200, description: 'Return all reviews.', type: [Review] })
   findAll() {
     return this.reviewsService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.reviewsService.findOne(id);
-  }
-
-  @Patch(':id')
-  @UseGuards(JwtAuthGuard)
-  update(@Param('id') id: string, @Body() updateReviewDto: UpdateReviewDto) {
-    return this.reviewsService.update(id, updateReviewDto);
-  }
-
-  @Delete(':id')
-  @UseGuards(JwtAuthGuard)
-  remove(@Param('id') id: string) {
-    return this.reviewsService.remove(id);
   }
 
   @Get('admin')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Admin: Get all reviews (paginated)' })
+  @ApiResponse({ status: 200, description: 'Return paginated reviews.', type: PageDto })
+  @ApiQuery({ name: 'status', enum: ReviewStatus, required: false })
   findAllAdmin(
     @Query() paginationQuery: PaginationQueryDto,
     @Query('status') status?: ReviewStatus,
@@ -67,6 +68,9 @@ export class ReviewsController {
   @Patch('admin/:id/publish')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Admin: Publish a review' })
+  @ApiResponse({ status: 200, description: 'Review published.', type: Review })
   publish(@Param('id') id: string) {
     return this.reviewsService.publish(id);
   }
@@ -74,18 +78,60 @@ export class ReviewsController {
   @Patch('admin/:id/unpublish')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Admin: Unpublish a review' })
+  @ApiResponse({ status: 200, description: 'Review unpublished.', type: Review })
   unpublish(@Param('id') id: string) {
     return this.reviewsService.unpublish(id);
   }
 
+  @Get(':id')
+  @UseGuards(OptionalJwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get a review by id' })
+  @ApiResponse({ status: 200, description: 'Return the review.', type: Review })
+  findOne(@Param('id') id: string, @Request() req) {
+    return this.reviewsService.findOne(id, req.user);
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update a review' })
+  @ApiResponse({ status: 200, description: 'Review successfully updated.', type: Review })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  update(
+    @Param('id') id: string,
+    @Body() updateReviewDto: UpdateReviewDto,
+    @Request() req,
+  ) {
+    return this.reviewsService.update(id, updateReviewDto, req.user);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Delete a review' })
+  @ApiResponse({ status: 200, description: 'Review successfully deleted.' })
+  @ApiResponse({ status: 403, description: 'Forbidden.' })
+  remove(@Param('id') id: string, @Request() req) {
+    return this.reviewsService.remove(id, req.user);
+  }
+
   @UseGuards(OptionalJwtAuthGuard)
   @Get('user/:userId')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get reviews by user' })
+  @ApiResponse({ status: 200, description: 'Return user reviews.', type: [Review] })
   findUserReviews(@Param('userId') userId: string, @Request() req) {
     return this.reviewsService.findUserReviews(userId, req.user);
   }
 
   @UseGuards(OptionalJwtAuthGuard)
   @Get('business/:businessId')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get reviews by business' })
+  @ApiResponse({ status: 200, description: 'Return business reviews.', type: [Review] })
   findBusinessReviews(@Param('businessId') businessId: string, @Request() req) {
     return this.reviewsService.findBusinessReviews(businessId, req.user);
   }

--- a/apps/mcom_mallAPI/src/resources/reviews/reviews.controller.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/reviews.controller.ts
@@ -8,16 +8,23 @@ import {
   Delete,
   UseGuards,
   Request,
+  Query,
 } from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../../common/guards/optional-jwt-auth.guard';
 import { Public } from 'src/common/decorators/public.decorator';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { UserRole } from '../../common/role.enum';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { ReviewStatus } from './entities/review.entity';
 
 @Controller('reviews')
 export class ReviewsController {
-  constructor(private readonly reviewsService: ReviewsService) { }
+  constructor(private readonly reviewsService: ReviewsService) {}
 
   @Post()
   @UseGuards(JwtAuthGuard)
@@ -47,14 +54,39 @@ export class ReviewsController {
     return this.reviewsService.remove(id);
   }
 
-  @Get('user/:userId')
-  findUserReviews(@Param('userId') userId: string) {
-    return this.reviewsService.findUserReviews(userId);
+  @Get('admin')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  findAllAdmin(
+    @Query() paginationQuery: PaginationQueryDto,
+    @Query('status') status?: ReviewStatus,
+  ) {
+    return this.reviewsService.findAllAdmin({ ...paginationQuery, status });
   }
 
-  @Public()
+  @Patch('admin/:id/publish')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  publish(@Param('id') id: string) {
+    return this.reviewsService.publish(id);
+  }
+
+  @Patch('admin/:id/unpublish')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  unpublish(@Param('id') id: string) {
+    return this.reviewsService.unpublish(id);
+  }
+
+  @UseGuards(OptionalJwtAuthGuard)
+  @Get('user/:userId')
+  findUserReviews(@Param('userId') userId: string, @Request() req) {
+    return this.reviewsService.findUserReviews(userId, req.user);
+  }
+
+  @UseGuards(OptionalJwtAuthGuard)
   @Get('business/:businessId')
-  findBusinessReviews(@Param('businessId') businessId: string) {
-    return this.reviewsService.findBusinessReviews(businessId);
+  findBusinessReviews(@Param('businessId') businessId: string, @Request() req) {
+    return this.reviewsService.findBusinessReviews(businessId, req.user);
   }
 }

--- a/apps/mcom_mallAPI/src/resources/reviews/reviews.service.spec.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/reviews.service.spec.ts
@@ -2,16 +2,29 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ReviewsService } from './reviews.service';
-import { Review } from './entities/review.entity';
+import { Review, ReviewStatus } from './entities/review.entity';
 import { Business } from '../listings/entities/listing.entity';
 import { User } from '../users/entities/user.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
+import { NotFoundException } from '@nestjs/common';
 
 describe('ReviewsService', () => {
   let service: ReviewsService;
   let reviewRepository: Repository<Review>;
   let businessRepository: Repository<Business>;
+
+  const mockQueryBuilder = {
+    leftJoinAndSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getCount: jest.fn(),
+    getRawAndEntities: jest.fn(),
+  };
 
   const mockReviewRepository = {
     create: jest.fn(),
@@ -20,6 +33,7 @@ describe('ReviewsService', () => {
     findOne: jest.fn(),
     update: jest.fn(),
     delete: jest.fn(),
+    createQueryBuilder: jest.fn(() => mockQueryBuilder),
   };
 
   const mockBusinessRepository = {
@@ -27,6 +41,7 @@ describe('ReviewsService', () => {
   };
 
   beforeEach(async () => {
+    jest.clearAllMocks();
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReviewsService,
@@ -55,7 +70,7 @@ describe('ReviewsService', () => {
   });
 
   describe('create', () => {
-    it('should create a new review', async () => {
+    it('should create a new review with PENDING status', async () => {
       const createReviewDto: CreateReviewDto = {
         rating: 5,
         comment: 'Great!',
@@ -77,6 +92,7 @@ describe('ReviewsService', () => {
       });
       expect(mockReviewRepository.create).toHaveBeenCalledWith({
         ...createReviewDto,
+        status: ReviewStatus.PENDING,
         user,
         business,
       });
@@ -84,90 +100,125 @@ describe('ReviewsService', () => {
     });
   });
 
-  describe('findAll', () => {
-    it('should return an array of reviews', async () => {
-      const reviews = [new Review(), new Review()];
-      mockReviewRepository.find.mockResolvedValue(reviews);
-
-      const result = await service.findAll();
-
-      expect(result).toEqual(reviews);
-      expect(mockReviewRepository.find).toHaveBeenCalled();
-    });
-  });
-
-  describe('findOne', () => {
-    it('should return a single review', async () => {
-      const review = new Review();
-      mockReviewRepository.findOne.mockResolvedValue(review);
-
-      const result = await service.findOne('1');
-
-      expect(result).toEqual(review);
-      expect(mockReviewRepository.findOne).toHaveBeenCalledWith({
-        where: { id: '1' },
-      });
-    });
-  });
-
-  describe('update', () => {
-    it('should update a review', async () => {
-      const updateReviewDto: UpdateReviewDto = {
-        rating: 4,
-        comment: 'Good',
-      };
-      const review = new Review();
-      mockReviewRepository.update.mockResolvedValue(undefined);
-      mockReviewRepository.findOne.mockResolvedValue(review);
-
-      const result = await service.update('1', updateReviewDto);
-
-      expect(result).toEqual(review);
-      expect(mockReviewRepository.update).toHaveBeenCalledWith(
-        '1',
-        updateReviewDto,
-      );
-      expect(mockReviewRepository.findOne).toHaveBeenCalledWith({
-        where: { id: '1' },
-      });
-    });
-  });
-
-  describe('remove', () => {
-    it('should remove a review', async () => {
-      mockReviewRepository.delete.mockResolvedValue(undefined);
-
-      await service.remove('1');
-
-      expect(mockReviewRepository.delete).toHaveBeenCalledWith('1');
-    });
-  });
-
   describe('findUserReviews', () => {
-    it('should return all reviews for a user', async () => {
-      const reviews = [new Review(), new Review()];
+    it('should return all reviews for the user (including pending) if viewing own reviews', async () => {
+      const userId = 'user1';
+      const currentUser = { id: 'user1' } as User;
+      const reviews = [new Review()];
       mockReviewRepository.find.mockResolvedValue(reviews);
 
-      const result = await service.findUserReviews('1');
+      const result = await service.findUserReviews(userId, currentUser);
 
       expect(result).toEqual(reviews);
       expect(mockReviewRepository.find).toHaveBeenCalledWith({
-        where: { user: { id: '1' } },
+        where: { user: { id: userId } },
+      });
+    });
+
+    it('should return only published reviews if viewing other user reviews', async () => {
+      const userId = 'user1';
+      const currentUser = { id: 'user2' } as User;
+      const reviews = [new Review()];
+      mockReviewRepository.find.mockResolvedValue(reviews);
+
+      const result = await service.findUserReviews(userId, currentUser);
+
+      expect(result).toEqual(reviews);
+      expect(mockReviewRepository.find).toHaveBeenCalledWith({
+        where: {
+          user: { id: userId },
+          status: ReviewStatus.PUBLISHED,
+        },
       });
     });
   });
 
   describe('findBusinessReviews', () => {
-    it('should return all reviews for a business', async () => {
-      const reviews = [new Review(), new Review()];
-      mockReviewRepository.find.mockResolvedValue(reviews);
+    it('should query with published status only if no current user', async () => {
+      const businessId = 'biz1';
+      const reviews = [new Review()];
+      mockQueryBuilder.getMany.mockResolvedValue(reviews);
 
-      const result = await service.findBusinessReviews('1');
+      const result = await service.findBusinessReviews(businessId);
 
+      expect(mockReviewRepository.createQueryBuilder).toHaveBeenCalledWith('review');
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith('business.id = :businessId', { businessId });
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith('review.status = :published', { published: ReviewStatus.PUBLISHED });
       expect(result).toEqual(reviews);
-      expect(mockReviewRepository.find).toHaveBeenCalledWith({
-        where: { business: { id: '1' } },
-      });
+    });
+
+    it('should query with pending visibility if current user is present', async () => {
+      const businessId = 'biz1';
+      const currentUser = { id: 'user1' } as User;
+      const reviews = [new Review()];
+      mockQueryBuilder.getMany.mockResolvedValue(reviews);
+
+      const result = await service.findBusinessReviews(businessId, currentUser);
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(expect.any(Object)); // Brackets logic is complex to match exactly with jest mocks, checking it was called is a good start.
+      expect(result).toEqual(reviews);
+    });
+  });
+
+  describe('findAllAdmin', () => {
+    it('should return paginated reviews', async () => {
+      const query = { page: 1, limit: 10 };
+      const reviews = [new Review()];
+      const itemCount = 1;
+      mockQueryBuilder.getCount.mockResolvedValue(itemCount);
+      mockQueryBuilder.getRawAndEntities.mockResolvedValue({ entities: reviews });
+
+      const result = await service.findAllAdmin(query);
+
+      expect(mockQueryBuilder.take).toHaveBeenCalledWith(10);
+      expect(mockQueryBuilder.skip).toHaveBeenCalledWith(0);
+      expect(result.data).toEqual(reviews);
+      expect(result.meta.totalItems).toEqual(itemCount);
+    });
+
+    it('should filter by status if provided', async () => {
+        const query = { page: 1, limit: 10, status: ReviewStatus.PENDING };
+        mockQueryBuilder.getCount.mockResolvedValue(0);
+        mockQueryBuilder.getRawAndEntities.mockResolvedValue({ entities: [] });
+
+        await service.findAllAdmin(query);
+
+        expect(mockQueryBuilder.where).toHaveBeenCalledWith('review.status = :status', { status: ReviewStatus.PENDING });
+    });
+  });
+
+  describe('publish', () => {
+    it('should publish a review', async () => {
+      const id = '1';
+      const review = new Review();
+      review.status = ReviewStatus.PENDING;
+      mockReviewRepository.findOne.mockResolvedValue(review);
+      mockReviewRepository.save.mockResolvedValue({ ...review, status: ReviewStatus.PUBLISHED });
+
+      const result = await service.publish(id);
+
+      expect(result.status).toEqual(ReviewStatus.PUBLISHED);
+      expect(mockReviewRepository.save).toHaveBeenCalledWith(expect.objectContaining({ status: ReviewStatus.PUBLISHED }));
+    });
+
+    it('should throw NotFoundException if review not found', async () => {
+        mockReviewRepository.findOne.mockResolvedValue(null);
+        await expect(service.publish('1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('unpublish', () => {
+    it('should unpublish a review', async () => {
+      const id = '1';
+      const review = new Review();
+      review.status = ReviewStatus.PUBLISHED;
+      mockReviewRepository.findOne.mockResolvedValue(review);
+      mockReviewRepository.save.mockResolvedValue({ ...review, status: ReviewStatus.PENDING });
+
+      const result = await service.unpublish(id);
+
+      expect(result.status).toEqual(ReviewStatus.PENDING);
+      expect(mockReviewRepository.save).toHaveBeenCalledWith(expect.objectContaining({ status: ReviewStatus.PENDING }));
     });
   });
 });

--- a/apps/mcom_mallAPI/src/resources/reviews/reviews.service.spec.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/reviews.service.spec.ts
@@ -7,7 +7,8 @@ import { Business } from '../listings/entities/listing.entity';
 import { User } from '../users/entities/user.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { UserRole } from '../../common/role.enum';
 
 describe('ReviewsService', () => {
   let service: ReviewsService;
@@ -97,6 +98,135 @@ describe('ReviewsService', () => {
         business,
       });
       expect(mockReviewRepository.save).toHaveBeenCalledWith(review);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return only published reviews', async () => {
+      const reviews = [new Review()];
+      mockReviewRepository.find.mockResolvedValue(reviews);
+
+      const result = await service.findAll();
+
+      expect(result).toEqual(reviews);
+      expect(mockReviewRepository.find).toHaveBeenCalledWith({
+        where: { status: ReviewStatus.PUBLISHED },
+      });
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return published review', async () => {
+        const id = '1';
+        const review = { id, status: ReviewStatus.PUBLISHED } as Review;
+        mockReviewRepository.findOne.mockResolvedValue(review);
+
+        const result = await service.findOne(id);
+
+        expect(result).toEqual(review);
+    });
+
+    it('should return pending review to admin', async () => {
+        const id = '1';
+        const review = { id, status: ReviewStatus.PENDING } as Review;
+        const admin = { id: 'admin', role: UserRole.ADMIN } as User;
+        mockReviewRepository.findOne.mockResolvedValue(review);
+
+        const result = await service.findOne(id, admin);
+
+        expect(result).toEqual(review);
+    });
+
+    it('should return pending review to reviewer', async () => {
+        const id = '1';
+        const reviewer = { id: 'reviewer' } as User;
+        const review = { id, status: ReviewStatus.PENDING, user: { id: 'reviewer' } } as Review;
+        mockReviewRepository.findOne.mockResolvedValue(review);
+
+        const result = await service.findOne(id, reviewer);
+
+        expect(result).toEqual(review);
+    });
+
+    it('should return pending review to business owner', async () => {
+        const id = '1';
+        const owner = { id: 'owner' } as User;
+        const review = { id, status: ReviewStatus.PENDING, user: { id: 'reviewer' }, business: { user: { id: 'owner' } } } as Review;
+        mockReviewRepository.findOne.mockResolvedValue(review);
+
+        const result = await service.findOne(id, owner);
+
+        expect(result).toEqual(review);
+    });
+
+    it('should throw NotFoundException for pending review if user not authorized', async () => {
+        const id = '1';
+        const user = { id: 'other' } as User;
+        const review = { id, status: ReviewStatus.PENDING, user: { id: 'reviewer' }, business: { user: { id: 'owner' } } } as Review;
+        mockReviewRepository.findOne.mockResolvedValue(review);
+
+        await expect(service.findOne(id, user)).rejects.toThrow(NotFoundException);
+    });
+
+     it('should return null (or throw) if not found', async () => {
+         mockReviewRepository.findOne.mockResolvedValue(null);
+         await expect(service.findOne('1')).rejects.toThrow(NotFoundException);
+     });
+  });
+
+  describe('update', () => {
+    it('should allow admin to update any review', async () => {
+      const updateReviewDto: UpdateReviewDto = { rating: 4 };
+      const adminUser = { id: 'admin1', role: UserRole.ADMIN } as User;
+      const review = { id: '1', user: { id: 'user1' } } as Review;
+
+      mockReviewRepository.findOne.mockResolvedValue(review);
+      mockReviewRepository.update.mockResolvedValue(undefined);
+
+      await service.update('1', updateReviewDto, adminUser);
+
+      expect(mockReviewRepository.update).toHaveBeenCalledWith(
+        '1',
+        updateReviewDto,
+      );
+    });
+
+    it('should allow owner to update their own review', async () => {
+      const updateReviewDto: UpdateReviewDto = { rating: 4 };
+      const user = { id: 'user1', role: UserRole.CUSTOMER } as User;
+      const review = { id: '1', user: { id: 'user1' } } as Review;
+
+      mockReviewRepository.findOne.mockResolvedValue(review);
+      mockReviewRepository.update.mockResolvedValue(undefined);
+
+      await service.update('1', updateReviewDto, user);
+
+      expect(mockReviewRepository.update).toHaveBeenCalledWith(
+        '1',
+        updateReviewDto,
+      );
+    });
+
+    it('should throw ForbiddenException if user tries to update another user review', async () => {
+      const updateReviewDto: UpdateReviewDto = { rating: 4 };
+      const user = { id: 'user2', role: UserRole.CUSTOMER } as User;
+      const review = { id: '1', user: { id: 'user1' } } as Review;
+
+      mockReviewRepository.findOne.mockResolvedValue(review);
+
+      await expect(
+        service.update('1', updateReviewDto, user),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException if review not found', async () => {
+      const updateReviewDto: UpdateReviewDto = { rating: 4 };
+      const user = { id: 'user1' } as User;
+      mockReviewRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.update('1', updateReviewDto, user),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -219,6 +349,52 @@ describe('ReviewsService', () => {
 
       expect(result.status).toEqual(ReviewStatus.PENDING);
       expect(mockReviewRepository.save).toHaveBeenCalledWith(expect.objectContaining({ status: ReviewStatus.PENDING }));
+    });
+  });
+
+  describe('remove', () => {
+    it('should allow admin to delete any review', async () => {
+      const id = '1';
+      const adminUser = { id: 'admin1', role: UserRole.ADMIN } as User;
+      const review = { id: '1', user: { id: 'user1' } } as Review;
+
+      mockReviewRepository.findOne.mockResolvedValue(review);
+      mockReviewRepository.delete.mockResolvedValue(undefined);
+
+      await service.remove(id, adminUser);
+
+      expect(mockReviewRepository.delete).toHaveBeenCalledWith(id);
+    });
+
+    it('should allow owner to delete their own review', async () => {
+      const id = '1';
+      const user = { id: 'user1', role: UserRole.CUSTOMER } as User;
+      const review = { id: '1', user: { id: 'user1' } } as Review;
+
+      mockReviewRepository.findOne.mockResolvedValue(review);
+      mockReviewRepository.delete.mockResolvedValue(undefined);
+
+      await service.remove(id, user);
+
+      expect(mockReviewRepository.delete).toHaveBeenCalledWith(id);
+    });
+
+    it('should throw ForbiddenException if user tries to delete another user review', async () => {
+      const id = '1';
+      const user = { id: 'user2', role: UserRole.CUSTOMER } as User;
+      const review = { id: '1', user: { id: 'user1' } } as Review;
+
+      mockReviewRepository.findOne.mockResolvedValue(review);
+
+      await expect(service.remove(id, user)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException if review not found', async () => {
+      const id = '1';
+      const user = { id: 'user1' } as User;
+      mockReviewRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.remove(id, user)).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/apps/mcom_mallAPI/src/resources/reviews/reviews.service.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/reviews.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, Brackets } from 'typeorm';
 import { Review, ReviewStatus } from './entities/review.entity';
@@ -7,6 +7,7 @@ import { UpdateReviewDto } from './dto/update-review.dto';
 import { User } from '../users/entities/user.entity';
 import { Business } from '../listings/entities/listing.entity';
 import { PageDto } from '../../common/dto/page.dto';
+import { UserRole } from '../../common/role.enum';
 import { PageMetaDto } from '../../common/dto/page-meta.dto';
 import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
@@ -33,19 +34,72 @@ export class ReviewsService {
   }
 
   async findAll(): Promise<Review[]> {
-    return this.reviewRepository.find();
+    return this.reviewRepository.find({
+      where: { status: ReviewStatus.PUBLISHED },
+    });
   }
 
-  async findOne(id: string): Promise<Review> {
-    return this.reviewRepository.findOne({ where: { id } });
+  async findOne(id: string, currentUser?: User): Promise<Review> {
+    const review = await this.findByIdInternal(id);
+
+    if (!review) {
+      throw new NotFoundException(`Review with ID ${id} not found`);
+    }
+
+    if (review.status === ReviewStatus.PUBLISHED) {
+      return review;
+    }
+
+    if (currentUser) {
+      if (currentUser.role === UserRole.ADMIN) {
+        return review;
+      }
+      if (review.user?.id === currentUser.id) {
+        return review;
+      }
+      if (review.business?.user?.id === currentUser.id) {
+        return review;
+      }
+    }
+
+    throw new NotFoundException(`Review with ID ${id} not found`);
   }
 
-  async update(id: string, updateReviewDto: UpdateReviewDto): Promise<Review> {
+  private async findByIdInternal(id: string): Promise<Review> {
+    return this.reviewRepository.findOne({
+      where: { id },
+      relations: ['user', 'business', 'business.user'],
+    });
+  }
+
+  async update(
+    id: string,
+    updateReviewDto: UpdateReviewDto,
+    user: User,
+  ): Promise<Review> {
+    const review = await this.findByIdInternal(id);
+    if (!review) {
+      throw new NotFoundException(`Review with ID ${id} not found`);
+    }
+
+    if (user.role !== UserRole.ADMIN && review.user?.id !== user.id) {
+      throw new ForbiddenException('You are not allowed to update this review');
+    }
+
     await this.reviewRepository.update(id, updateReviewDto);
-    return this.findOne(id);
+    return this.findByIdInternal(id);
   }
 
-  async remove(id: string): Promise<void> {
+  async remove(id: string, user: User): Promise<void> {
+    const review = await this.findByIdInternal(id);
+    if (!review) {
+      throw new NotFoundException(`Review with ID ${id} not found`);
+    }
+
+    if (user.role !== UserRole.ADMIN && review.user?.id !== user.id) {
+      throw new ForbiddenException('You are not allowed to delete this review');
+    }
+
     await this.reviewRepository.delete(id);
   }
 
@@ -123,7 +177,7 @@ export class ReviewsService {
   }
 
   async publish(id: string): Promise<Review> {
-    const review = await this.findOne(id);
+    const review = await this.findByIdInternal(id);
     if (!review) {
       throw new NotFoundException(`Review with ID ${id} not found`);
     }
@@ -132,7 +186,7 @@ export class ReviewsService {
   }
 
   async unpublish(id: string): Promise<Review> {
-    const review = await this.findOne(id);
+    const review = await this.findByIdInternal(id);
     if (!review) {
       throw new NotFoundException(`Review with ID ${id} not found`);
     }

--- a/apps/mcom_mallAPI/src/resources/reviews/reviews.service.ts
+++ b/apps/mcom_mallAPI/src/resources/reviews/reviews.service.ts
@@ -1,11 +1,14 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Review } from './entities/review.entity';
+import { Repository, Brackets } from 'typeorm';
+import { Review, ReviewStatus } from './entities/review.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { User } from '../users/entities/user.entity';
 import { Business } from '../listings/entities/listing.entity';
+import { PageDto } from '../../common/dto/page.dto';
+import { PageMetaDto } from '../../common/dto/page-meta.dto';
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
 
 @Injectable()
 export class ReviewsService {
@@ -22,6 +25,7 @@ export class ReviewsService {
     });
     const review = this.reviewRepository.create({
       ...createReviewDto,
+      status: ReviewStatus.PENDING,
       user,
       business,
     });
@@ -45,13 +49,94 @@ export class ReviewsService {
     await this.reviewRepository.delete(id);
   }
 
-  async findUserReviews(userId: string): Promise<Review[]> {
-    return this.reviewRepository.find({ where: { user: { id: userId } } });
+  async findUserReviews(userId: string, currentUser?: User): Promise<Review[]> {
+    if (currentUser?.id === userId) {
+      return this.reviewRepository.find({ where: { user: { id: userId } } });
+    }
+    return this.reviewRepository.find({
+      where: {
+        user: { id: userId },
+        status: ReviewStatus.PUBLISHED,
+      },
+    });
   }
 
-  async findBusinessReviews(businessId: string): Promise<Review[]> {
-    return this.reviewRepository.find({
-      where: { business: { id: businessId } },
+  async findBusinessReviews(
+    businessId: string,
+    currentUser?: User,
+  ): Promise<Review[]> {
+    const qb = this.reviewRepository
+      .createQueryBuilder('review')
+      .leftJoinAndSelect('review.user', 'reviewer')
+      .leftJoinAndSelect('review.business', 'business')
+      .leftJoinAndSelect('business.user', 'owner')
+      .where('business.id = :businessId', { businessId });
+
+    if (currentUser) {
+      qb.andWhere(
+        new Brackets((qb) => {
+          qb.where('review.status = :published', {
+            published: ReviewStatus.PUBLISHED,
+          })
+            .orWhere('reviewer.id = :userId', { userId: currentUser.id })
+            .orWhere('owner.id = :userId', { userId: currentUser.id });
+        }),
+      );
+    } else {
+      qb.andWhere('review.status = :published', {
+        published: ReviewStatus.PUBLISHED,
+      });
+    }
+
+    return qb.getMany();
+  }
+
+  async findAllAdmin(
+    paginationQuery: PaginationQueryDto & { status?: ReviewStatus },
+  ): Promise<PageDto<Review>> {
+    const { page, limit, status } = paginationQuery;
+    const skip = (page - 1) * limit;
+
+    const queryBuilder = this.reviewRepository.createQueryBuilder('review');
+
+    if (status) {
+      queryBuilder.where('review.status = :status', { status });
+    }
+
+    queryBuilder
+      .leftJoinAndSelect('review.user', 'user')
+      .leftJoinAndSelect('review.business', 'business')
+      .orderBy('review.createdAt', 'DESC')
+      .skip(skip)
+      .take(limit);
+
+    const itemCount = await queryBuilder.getCount();
+    const { entities } = await queryBuilder.getRawAndEntities();
+
+    const pageMetaDto = new PageMetaDto({
+      itemCount,
+      pageOptionsDto: paginationQuery,
+      totalItems: itemCount,
     });
+
+    return new PageDto(entities, pageMetaDto);
+  }
+
+  async publish(id: string): Promise<Review> {
+    const review = await this.findOne(id);
+    if (!review) {
+      throw new NotFoundException(`Review with ID ${id} not found`);
+    }
+    review.status = ReviewStatus.PUBLISHED;
+    return this.reviewRepository.save(review);
+  }
+
+  async unpublish(id: string): Promise<Review> {
+    const review = await this.findOne(id);
+    if (!review) {
+      throw new NotFoundException(`Review with ID ${id} not found`);
+    }
+    review.status = ReviewStatus.PENDING;
+    return this.reviewRepository.save(review);
   }
 }


### PR DESCRIPTION
This PR implements a review approval workflow where reviews are created as pending by default. It restricts visibility of pending reviews to the reviewer and the business owner. It also adds admin-only endpoints to list pending reviews (with pagination and filtering), and to publish or unpublish them.

---
*PR created automatically by Jules for task [9037893824215849893](https://jules.google.com/task/9037893824215849893) started by @Azeem-py*