### PR TITLE
Integrate Multi-Timer Activity Status API

### DIFF
--- a/app/dashboard/activity-timer/page.tsx
+++ b/app/dashboard/activity-timer/page.tsx
@@ -1,67 +1,13 @@
 "use client";
 
-import { FC, useState, useEffect, useRef } from "react";
-import { useGetTrialStatus, usePauseOrPlay } from "@/service/payments/hook";
-import { TrialAction, TrialTasks } from "@/service/payments/types";
+import { FC } from "react";
+import { useGetActivityTimers } from "@/service/activity-timer/hook";
 import { motion } from "framer-motion";
-import {
-  PlayIcon,
-  PauseIcon,
-  CheckCircle2,
-  Loader,
-  TimerOff,
-} from "lucide-react";
-import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import StyledNumber from "@/components/svgs/StyledNumber";
-
-const TimeCard: FC<{ value: string; unit: string }> = ({ value, unit }) => (
-  <div className="flex flex-col items-center justify-center bg-orange-600 p-4 rounded-lg w-24 h-24">
-    <span className="text-4xl font-bold tracking-tight text-white">
-      {value}
-    </span>
-    <span className="text-sm font-light uppercase text-white">{unit}</span>
-  </div>
-);
+import { Loader, TimerOff } from "lucide-react";
+import ActivityPageTimer from "@/components/ActivityPageTimer";
 
 const ActivityTimerPage: FC = () => {
-  const { data: trialStatus, isLoading, error } = useGetTrialStatus();
-  const { mutate: pauseOrPlay, isPending } = usePauseOrPlay();
-  const [timeLeft, setTimeLeft] = useState(0);
-  const timerInitialized = useRef(false);
-
-  useEffect(() => {
-    if (trialStatus && timerInitialized.current === false) {
-      setTimeLeft(trialStatus.remainingTime);
-      timerInitialized.current = true;
-    }
-  }, [trialStatus]);
-
-  useEffect(() => {
-    if (trialStatus?.isPaused) return;
-
-    const interval = setInterval(() => {
-      setTimeLeft((prevTime) => (prevTime > 0 ? prevTime - 1000 : 0));
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, [trialStatus?.isPaused]);
-
-  const formatTime = (ms: number) => {
-    const totalSeconds = Math.floor(ms / 1000);
-    const days = Math.floor(totalSeconds / 86400);
-    const hours = Math.floor((totalSeconds % 86400) / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const seconds = totalSeconds % 60;
-    return {
-      days: String(days).padStart(2, "0"),
-      hours: String(hours).padStart(2, "0"),
-      minutes: String(minutes).padStart(2, "0"),
-      seconds: String(seconds).padStart(2, "0"),
-    };
-  };
-
-  const formattedTime = formatTime(timeLeft);
+  const { data: timers, isLoading, error } = useGetActivityTimers();
 
   if (isLoading) {
     return (
@@ -79,76 +25,41 @@ const ActivityTimerPage: FC = () => {
             An Error Occurred
           </h2>
           <p className="text-gray-500 mt-2">
-            We couldn&apos;t load the trial status. Please try again later.
+            We couldn&apos;t load the activity timers. Please try again later.
           </p>
         </div>
       </div>
     );
   }
 
-  if (!trialStatus) {
+  if (!timers || timers.length === 0) {
     return (
       <div className="flex items-center justify-center min-h-[calc(100vh-8rem)]">
         <div className="text-center">
           <TimerOff className="w-16 h-16 mx-auto text-gray-400 mb-4" />
           <h2 className="text-2xl font-semibold text-gray-700">
-            No Active Activity Timer
+            No Active Activity Timers
           </h2>
           <p className="text-gray-500 mt-2">
-            No active activity timer found for this business.
+            No active activity timers found for your account.
           </p>
         </div>
       </div>
     );
   }
 
-  const { tasks, isPaused, isTrialPausable, remainingPauses } = trialStatus;
-
-  const taskKeys = Object.keys(tasks) as (keyof TrialTasks)[];
-
-  const taskDetails: Record<
-    keyof TrialTasks,
-    { title: string; description: string; url: string }
-  > = {
-    createdBusiness: {
-      title: "Add Business Listing",
-      description:
-        "What it means: Create a profile for your business to start selling.",
-      url: "/dashboard/add-listing",
-    },
-    createdProductOrService: {
-      title: "Import your Contact Information",
-      description: "What it means: Upload your contact database that you will like to let them know your offer on MCOM.",
-      url: "/dashboard/my-profile",
-    },
-    createdPromotion: {
-      title: "Add at least 1 product/service",
-      description: "What it means: The business creates a product or service listing on the platform. How we check it: The system looks for at least one active product linked to the account.",
-      url: "/dashboard/services/add-service",
-    },
-    createdOffer: {
-      title: "List at least 1 barter offer",
-      description: "What it means: The business publishes an offer they will barter or exchange with others. How we check it: The system checks that a barter offer record exists and is active.",
-      url: "/dashboard/add-listing",
-    },
-    createdCoupon: {
-      title: "Connect with at least 1 other business",
-      description: "What it means: The business sends or accepts a connection (network) request with another verified business. How we check it: The system looks for at least one confirmed connection between accounts.",
-      url: "/dashboard/messages",
-    },
-  };
+  const filteredTimers = timers.filter((t) => t.type !== 'GENERAL');
 
   return (
     <div className="min-h-[calc(100vh-8rem)] bg-white text-black p-4 sm:p-6 md:p-8">
       <div className="max-w-6xl mx-auto">
-        {/* Header */}
-        <header className="text-center mb-8">
+        <header className="text-center mb-12">
           <motion.h1
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
             className="text-3xl font-extrabold tracking-tight sm:text-4xl md:text-5xl"
           >
-            Your Trial Dashboard
+            Your Activity Dashboard
           </motion.h1>
           <motion.p
             initial={{ opacity: 0, y: 20 }}
@@ -156,106 +67,19 @@ const ActivityTimerPage: FC = () => {
             transition={{ delay: 0.2 }}
             className="mt-4 text-base sm:text-lg text-black"
           >
-            Complete the tasks below to make the most of your trial period.
+            Manage your active timers and complete tasks to unlock more features.
           </motion.p>
         </header>
 
-        {/* Countdown Timer */}
-        <motion.section
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ delay: 0.3 }}
-          className="mb-8"
-        >
-          <div className="flex flex-wrap justify-center items-center gap-2 sm:gap-4 mb-4">
-            {Object.entries(formattedTime).map(([unit, value]) => (
-              <TimeCard key={unit} value={value} unit={unit} />
-            ))}
+        {filteredTimers.length > 0 ? (
+          filteredTimers.map((timer) => (
+            <ActivityPageTimer key={timer.id} timer={timer} />
+          ))
+        ) : (
+          <div className="text-center py-20 border-2 border-dashed border-gray-200 rounded-xl">
+             <p className="text-gray-500">No trial activities currently active.</p>
           </div>
-
-          {isTrialPausable && (
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-6">
-              <Button
-                onClick={() =>
-                  pauseOrPlay({
-                    action: isPaused ? TrialAction.RESUME : TrialAction.PAUSE,
-                  })
-                }
-                disabled={
-                  isPending || (!isPaused && (remainingPauses ?? 0) <= 0)
-                }
-                size="lg"
-                className="bg-orange-600 hover:bg-orange-700 text-white font-bold w-full sm:w-auto"
-              >
-                {isPending ? (
-                  <Loader className="w-5 h-5 animate-spin" />
-                ) : isPaused ? (
-                  <>
-                    <PlayIcon className="w-5 h-5 mr-2" /> Resume
-                  </>
-                ) : (
-                  <>
-                    <PauseIcon className="w-5 h-5 mr-2" /> Pause
-                  </>
-                )}
-              </Button>
-              <span className="text-sm text-black">
-                ({remainingPauses} pause
-                {remainingPauses !== 1 ? "s" : ""} left)
-              </span>
-            </div>
-          )}
-        </motion.section>
-
-        {/* New Task Display */}
-        <div className="w-full mx-auto">
-          <h2 className="text-2xl sm:text-3xl font-bold text-black mb-8 text-center sm:text-left sm:ml-4">
-            Get started with Mcommall
-          </h2>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 p-0 sm:p-4">
-            {taskKeys.map((taskKey, index) => {
-              const task = taskDetails[taskKey];
-              const isCompleted = tasks[taskKey];
-              return (
-                <div
-                  key={taskKey}
-                  className="bg-white border-2 border-orange-400 shadow-xl rounded-2xl p-4 sm:p-8 flex flex-col sm:flex-row items-center sm:items-start gap-4"
-                >
-                  <div className="w-full sm:w-1/3 flex items-center justify-center text-orange-500">
-                    <span className="text-orange-500 transform scale-75 sm:scale-100">
-                      <StyledNumber number={index + 1} />
-                    </span>
-                  </div>
-                  <div className="w-full sm:w-2/3 flex flex-col justify-between h-full">
-                    <div>
-                      <h3 className="text-lg sm:text-xl font-bold text-gray-900 mb-2 text-center sm:text-left">
-                        {task.title}
-                      </h3>
-                      <p className="text-black mb-4 text-sm text-center sm:text-left">
-                        {task.description}
-                      </p>
-                    </div>
-                    <div className="flex items-center justify-center sm:justify-start mt-auto">
-                      {isCompleted ? (
-                        <button className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold transition-colors bg-green-600 text-white w-full sm:w-auto">
-                          <CheckCircle2 className="w-4 h-4 mr-2" />
-                          Done
-                        </button>
-                      ) : (
-                        <Link
-                          href={task.url}
-                          className="flex items-center justify-center sm:justify-start text-orange-500 hover:text-orange-400 font-medium text-sm w-full sm:w-auto"
-                        >
-                          Finish this activity
-                        </Link>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import { useGetTrialStatus } from '@/service/payments/hook';
+import { useGetActivityTimers } from '@/service/activity-timer/hook';
 import TrialCountdownTimer from '@/components/TrialCountdownTimer';
 import { SubscriptionStatusEnum } from '@/service/payments/types';
 import ProtectedRoute from '@/components/ProtectedRoute';
@@ -33,7 +33,9 @@ export default function DashboardLayout({
   const [mounted, setMounted] = useState(false);
   const [isSideMenuOpen, setIsSideMenuOpen] = useState(false);
   const [isQuickActionsOpen, setIsQuickActionsOpen] = useState(false);
-  const { data: trialStatus } = useGetTrialStatus();
+  const { data: timers } = useGetActivityTimers();
+
+  const generalTimer = timers?.find((t) => t.type === 'GENERAL');
 
   useEffect(() => {
     setMounted(true);
@@ -46,8 +48,8 @@ export default function DashboardLayout({
   return (
     <>
       <AuthRedirect />
-      {trialStatus?.isActive && (
-        <TrialCountdownTimer trialStatus={trialStatus} />
+      {generalTimer && (
+        <TrialCountdownTimer timer={generalTimer} />
       )}
       <section className="fixed inset-0 flex w-full h-full overflow-hidden bg-[#F6F6F6]">
         {/* --- DESKTOP SIDEBAR (Left) --- */}

--- a/components/ActivityPageTimer.tsx
+++ b/components/ActivityPageTimer.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { FC, useState, useEffect, useRef } from "react";
+import { ActivityTimer, ActivityTimerTask } from "@/service/activity-timer/types";
+import { usePauseOrPlay } from "@/service/payments/hook";
+import { TrialAction } from "@/service/payments/types";
+import { motion } from "framer-motion";
+import {
+  PlayIcon,
+  PauseIcon,
+  CheckCircle2,
+  Loader,
+} from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import StyledNumber from "@/components/svgs/StyledNumber";
+
+const TimeCard: FC<{ value: string; unit: string }> = ({ value, unit }) => (
+  <div className="flex flex-col items-center justify-center bg-orange-600 p-4 rounded-lg w-20 h-20 sm:w-24 sm:h-24">
+    <span className="text-2xl sm:text-4xl font-bold tracking-tight text-white">
+      {value}
+    </span>
+    <span className="text-[10px] sm:text-sm font-light uppercase text-white">{unit}</span>
+  </div>
+);
+
+interface ActivityPageTimerProps {
+  timer: ActivityTimer;
+}
+
+const ActivityPageTimer: FC<ActivityPageTimerProps> = ({ timer }) => {
+  const { mutate: pauseOrPlay, isPending } = usePauseOrPlay();
+  const [timeLeft, setTimeLeft] = useState(timer.remainingTime);
+  const timerInitialized = useRef(false);
+
+  useEffect(() => {
+    if (timer && !timerInitialized.current) {
+      setTimeLeft(timer.remainingTime);
+      timerInitialized.current = true;
+    }
+  }, [timer]);
+
+  useEffect(() => {
+    if (timer.isPaused) return;
+
+    const interval = setInterval(() => {
+      setTimeLeft((prevTime) => (prevTime > 0 ? prevTime - 1000 : 0));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [timer.isPaused]);
+
+  const formatTime = (ms: number) => {
+    const totalSeconds = Math.floor(ms / 1000);
+    const days = Math.floor(totalSeconds / 86400);
+    const hours = Math.floor((totalSeconds % 86400) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    return {
+      days: String(days).padStart(2, "0"),
+      hours: String(hours).padStart(2, "0"),
+      minutes: String(minutes).padStart(2, "0"),
+      seconds: String(seconds).padStart(2, "0"),
+    };
+  };
+
+  const formattedTime = formatTime(timeLeft);
+
+  // Derive pause info
+  const maxPauses = 2;
+  const pausesCount = timer.pauses?.length || 0;
+  const remainingPauses = Math.max(0, maxPauses - pausesCount);
+  const isPausable = remainingPauses > 0;
+
+  return (
+    <div className="mb-12 last:mb-0">
+      <header className="text-center mb-8">
+        <motion.h2
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-2xl font-bold tracking-tight sm:text-3xl"
+        >
+          {timer.name} Dashboard
+        </motion.h2>
+        <p className="mt-2 text-gray-600">
+          {timer.description}
+        </p>
+      </header>
+
+      {/* Countdown Timer */}
+      <motion.section
+        initial={{ opacity: 0, scale: 0.9 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ delay: 0.3 }}
+        className="mb-8"
+      >
+        <div className="flex flex-wrap justify-center items-center gap-2 sm:gap-4 mb-4">
+          {Object.entries(formattedTime).map(([unit, value]) => (
+            <TimeCard key={unit} value={value} unit={unit} />
+          ))}
+        </div>
+
+        {(isPausable || timer.isPaused) && (
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-6">
+            <Button
+              onClick={() =>
+                pauseOrPlay({
+                  action: timer.isPaused ? TrialAction.RESUME : TrialAction.PAUSE,
+                  timerId: timer.id,
+                })
+              }
+              disabled={
+                isPending || (!timer.isPaused && remainingPauses <= 0)
+              }
+              size="lg"
+              className="bg-orange-600 hover:bg-orange-700 text-white font-bold w-full sm:w-auto"
+            >
+              {isPending ? (
+                <Loader className="w-5 h-5 animate-spin" />
+              ) : timer.isPaused ? (
+                <>
+                  <PlayIcon className="w-5 h-5 mr-2" /> Resume
+                </>
+              ) : (
+                <>
+                  <PauseIcon className="w-5 h-5 mr-2" /> Pause
+                </>
+              )}
+            </Button>
+            <span className="text-sm text-black">
+              ({remainingPauses} pause
+              {remainingPauses !== 1 ? "s" : ""} left)
+            </span>
+          </div>
+        )}
+      </motion.section>
+
+      {/* Task Display */}
+      <div className="w-full mx-auto">
+        <h3 className="text-xl sm:text-2xl font-bold text-black mb-6 text-center sm:text-left sm:ml-4">
+          Tasks to complete
+        </h3>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 p-0 sm:p-4">
+          {timer.tasks.map((task, index) => {
+            return (
+              <div
+                key={task.key}
+                className="bg-white border-2 border-orange-400 shadow-xl rounded-2xl p-4 sm:p-8 flex flex-col sm:flex-row items-center sm:items-start gap-4"
+              >
+                <div className="w-full sm:w-1/3 flex items-center justify-center text-orange-500">
+                  <span className="text-orange-500 transform scale-75 sm:scale-100">
+                    <StyledNumber number={index + 1} />
+                  </span>
+                </div>
+                <div className="w-full sm:w-2/3 flex flex-col justify-between h-full">
+                  <div>
+                    <h4 className="text-lg font-bold text-gray-900 mb-2 text-center sm:text-left">
+                      {task.title}
+                    </h4>
+                    <p className="text-black mb-4 text-sm text-center sm:text-left">
+                      {task.description}
+                    </p>
+                  </div>
+                  <div className="flex items-center justify-center sm:justify-start mt-auto">
+                    {task.isCompleted ? (
+                      <button className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold transition-colors bg-green-600 text-white w-full sm:w-auto cursor-default">
+                        <CheckCircle2 className="w-4 h-4 mr-2" />
+                        Done
+                      </button>
+                    ) : (
+                      <Link
+                        href={task.url}
+                        className="flex items-center justify-center sm:justify-start text-orange-500 hover:text-orange-400 font-medium text-sm w-full sm:w-auto"
+                      >
+                        Finish this activity
+                      </Link>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="border-b border-gray-200 my-12" />
+    </div>
+  );
+};
+
+export default ActivityPageTimer;

--- a/components/ActivityPageTimer.tsx
+++ b/components/ActivityPageTimer.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useState, useEffect, useRef } from "react";
 import { ActivityTimer, ActivityTimerTask } from "@/service/activity-timer/types";
-import { usePauseOrPlay } from "@/service/payments/hook";
+import { usePauseOrResumeActivityTimer, useCompleteActivityTask } from "@/service/activity-timer/hook";
 import { TrialAction } from "@/service/payments/types";
 import { motion } from "framer-motion";
 import {
@@ -29,7 +29,8 @@ interface ActivityPageTimerProps {
 }
 
 const ActivityPageTimer: FC<ActivityPageTimerProps> = ({ timer }) => {
-  const { mutate: pauseOrPlay, isPending } = usePauseOrPlay();
+  const { mutate: pauseOrPlay, isPending } = usePauseOrResumeActivityTimer();
+  const { mutate: completeTask, isPending: isCompletingTask } = useCompleteActivityTask();
   const [timeLeft, setTimeLeft] = useState(timer.remainingTime);
   const timerInitialized = useRef(false);
 
@@ -162,19 +163,32 @@ const ActivityPageTimer: FC<ActivityPageTimerProps> = ({ timer }) => {
                     </p>
                   </div>
                   <div className="flex items-center justify-center sm:justify-start mt-auto">
-                    {task.isCompleted ? (
-                      <button className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold transition-colors bg-green-600 text-white w-full sm:w-auto cursor-default">
-                        <CheckCircle2 className="w-4 h-4 mr-2" />
-                        Done
-                      </button>
-                    ) : (
-                      <Link
-                        href={task.url}
-                        className="flex items-center justify-center sm:justify-start text-orange-500 hover:text-orange-400 font-medium text-sm w-full sm:w-auto"
-                      >
-                        Finish this activity
-                      </Link>
-                    )}
+                    <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                      {task.isCompleted ? (
+                        <button className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold transition-colors bg-green-600 text-white w-full sm:w-auto cursor-default">
+                          <CheckCircle2 className="w-4 h-4 mr-2" />
+                          Done
+                        </button>
+                      ) : (
+                        <>
+                          <Link
+                            href={task.url}
+                            className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold border border-orange-500 text-orange-500 hover:bg-orange-50 transition-colors w-full sm:w-auto"
+                          >
+                            Finish this activity
+                          </Link>
+                          <Button
+                            onClick={() => completeTask(task.key)}
+                            disabled={isCompletingTask}
+                            variant="outline"
+                            size="sm"
+                            className="text-xs border-green-600 text-green-600 hover:bg-green-50"
+                          >
+                            Mark as Done
+                          </Button>
+                        </>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/components/ActivityPageTimer.tsx
+++ b/components/ActivityPageTimer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FC, useState, useEffect, useRef } from "react";
-import { ActivityTimer, ActivityTimerTask } from "@/service/activity-timer/types";
+import { ActivityTimer } from "@/service/activity-timer/types";
 import { usePauseOrResumeActivityTimer } from "@/service/activity-timer/hook";
 import { TrialAction } from "@/service/payments/types";
 import { motion } from "framer-motion";
@@ -16,11 +16,11 @@ import { Button } from "@/components/ui/button";
 import StyledNumber from "@/components/svgs/StyledNumber";
 
 const TimeCard: FC<{ value: string; unit: string }> = ({ value, unit }) => (
-  <div className="flex flex-col items-center justify-center bg-orange-600 p-4 rounded-lg w-20 h-20 sm:w-24 sm:h-24">
-    <span className="text-2xl sm:text-4xl font-bold tracking-tight text-white">
+  <div className="flex flex-col items-center justify-center bg-orange-600 p-2 rounded-xl min-w-[70px] sm:min-w-[80px]">
+    <span className="text-xl sm:text-2xl font-bold tracking-tight text-white leading-none">
       {value}
     </span>
-    <span className="text-[10px] sm:text-sm font-light uppercase text-white">{unit}</span>
+    <span className="text-[10px] font-medium uppercase text-white/90 mt-1">{unit}</span>
   </div>
 );
 
@@ -73,104 +73,102 @@ const ActivityPageTimer: FC<ActivityPageTimerProps> = ({ timer }) => {
   const isPausable = remainingPauses > 0;
 
   return (
-    <div className="mb-12 last:mb-0">
-      <header className="text-center mb-8">
-        <motion.h2
-          initial={{ opacity: 0, y: -20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className="text-2xl font-bold tracking-tight sm:text-3xl"
-        >
-          {timer.name} Dashboard
-        </motion.h2>
-        <p className="mt-2 text-gray-600">
-          {timer.description}
-        </p>
-      </header>
-
-      {/* Countdown Timer */}
-      <motion.section
-        initial={{ opacity: 0, scale: 0.9 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ delay: 0.3 }}
-        className="mb-8"
-      >
-        <div className="flex flex-wrap justify-center items-center gap-2 sm:gap-4 mb-4">
-          {Object.entries(formattedTime).map(([unit, value]) => (
-            <TimeCard key={unit} value={value} unit={unit} />
-          ))}
-        </div>
-
-        {(isPausable || timer.isPaused) && (
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-6">
-            <Button
-              onClick={() =>
-                pauseOrPlay({
-                  action: timer.isPaused ? TrialAction.RESUME : TrialAction.PAUSE,
-                  timerId: timer.id,
-                })
-              }
-              disabled={
-                isPending || (!timer.isPaused && remainingPauses <= 0)
-              }
-              size="lg"
-              className="bg-orange-600 hover:bg-orange-700 text-white font-bold w-full sm:w-auto"
+    <div className="mb-12 last:mb-0 bg-white border border-gray-200 shadow-sm rounded-[2.5rem] overflow-hidden">
+      <div className="p-6 sm:p-10 md:p-12">
+        {/* Activity Header with Integrated Timer */}
+        <header className="flex flex-col lg:flex-row lg:items-center justify-between gap-8 mb-12">
+          <div className="flex-1">
+            <motion.h2
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              className="text-3xl font-extrabold tracking-tight text-gray-900 sm:text-4xl"
             >
-              {isPending ? (
-                <Loader className="w-5 h-5 animate-spin" />
-              ) : timer.isPaused ? (
-                <>
-                  <PlayIcon className="w-5 h-5 mr-2" /> Resume
-                </>
-              ) : (
-                <>
-                  <PauseIcon className="w-5 h-5 mr-2" /> Pause
-                </>
-              )}
-            </Button>
-            <span className="text-sm text-black">
-              ({remainingPauses} pause
-              {remainingPauses !== 1 ? "s" : ""} left)
-            </span>
+              {timer.name}
+            </motion.h2>
+            <p className="mt-3 text-lg text-gray-600 max-w-2xl">
+              {timer.description}
+            </p>
           </div>
-        )}
-      </motion.section>
 
-      {/* Task Display */}
-      <div className="w-full mx-auto">
-        <h3 className="text-xl sm:text-2xl font-bold text-black mb-6 text-center sm:text-left sm:ml-4">
-          Tasks to complete
-        </h3>
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 p-0 sm:p-4">
-          {timer.tasks.map((task, index) => {
-            return (
+          <div className="flex flex-col items-center lg:items-end gap-4">
+            <div className="flex flex-wrap justify-center gap-2">
+              {Object.entries(formattedTime).map(([unit, value]) => (
+                <TimeCard key={unit} value={value} unit={unit} />
+              ))}
+            </div>
+
+            {(isPausable || timer.isPaused) && (
+              <div className="flex items-center gap-3">
+                <Button
+                  onClick={() =>
+                    pauseOrPlay({
+                      action: timer.isPaused ? TrialAction.RESUME : TrialAction.PAUSE,
+                      timerId: timer.id,
+                    })
+                  }
+                  disabled={
+                    isPending || (!timer.isPaused && remainingPauses <= 0)
+                  }
+                  variant="outline"
+                  size="sm"
+                  className="rounded-full h-9 px-4 border-orange-200 text-orange-600 hover:bg-orange-50 font-semibold"
+                >
+                  {isPending ? (
+                    <Loader className="w-4 h-4 animate-spin" />
+                  ) : timer.isPaused ? (
+                    <>
+                      <PlayIcon className="w-4 h-4 mr-2" /> Resume
+                    </>
+                  ) : (
+                    <>
+                      <PauseIcon className="w-4 h-4 mr-2" /> Pause
+                    </>
+                  )}
+                </Button>
+                <span className="text-xs font-medium text-gray-400">
+                  {remainingPauses} pause{remainingPauses !== 1 ? "s" : ""} left
+                </span>
+              </div>
+            )}
+          </div>
+        </header>
+
+        {/* Task Grid */}
+        <div className="w-full">
+          <h3 className="text-2xl font-bold text-gray-900 mb-8 flex items-center gap-3">
+            Tasks to complete
+            <div className="h-px flex-1 bg-gray-100" />
+          </h3>
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            {timer.tasks.map((task, index) => (
               <div
                 key={task.key}
-                className="bg-white border-2 border-orange-400 shadow-xl rounded-2xl p-4 sm:p-8 flex flex-col sm:flex-row items-center sm:items-start gap-4"
+                className="bg-white border-2 border-orange-100 hover:border-orange-300 transition-colors shadow-sm rounded-3xl p-6 sm:p-8 flex flex-col sm:flex-row items-center sm:items-start gap-6"
               >
-                <div className="w-full sm:w-1/3 flex items-center justify-center text-orange-500">
-                  <span className="text-orange-500 transform scale-75 sm:scale-100">
+                <div className="flex-shrink-0">
+                  <span className="transform scale-90 sm:scale-100 block">
                     <StyledNumber number={index + 1} />
                   </span>
                 </div>
-                <div className="w-full sm:w-2/3 flex flex-col justify-between h-full">
+                <div className="flex-grow flex flex-col justify-between h-full text-center sm:text-left">
                   <div>
-                    <h4 className="text-lg font-bold text-gray-900 mb-2 text-center sm:text-left">
+                    <h4 className="text-xl font-bold text-gray-900 mb-2">
                       {task.title}
                     </h4>
-                    <p className="text-black mb-4 text-sm text-center sm:text-left">
+                    <p className="text-gray-600 mb-6 text-sm leading-relaxed">
                       {task.description}
                     </p>
                   </div>
-                  <div className="flex items-center justify-center sm:justify-start mt-auto">
+                  <div className="mt-auto">
                     {task.isCompleted ? (
-                      <button className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold transition-colors bg-green-600 text-white w-full sm:w-auto cursor-default">
+                      <div className="inline-flex items-center justify-center px-6 py-2.5 rounded-xl text-sm font-bold bg-green-50 text-green-600 border border-green-100">
                         <CheckCircle2 className="w-4 h-4 mr-2" />
-                        Done
-                      </button>
+                        Completed
+                      </div>
                     ) : (
                       <Link
                         href={task.url}
-                        className="flex items-center justify-center sm:justify-start text-orange-500 hover:text-orange-400 font-medium text-sm w-full sm:w-auto"
+                        className="inline-flex items-center justify-center px-6 py-2.5 rounded-xl text-sm font-bold bg-orange-600 text-white hover:bg-orange-700 transition-all shadow-md hover:shadow-lg"
                       >
                         Finish this activity
                       </Link>
@@ -178,11 +176,10 @@ const ActivityPageTimer: FC<ActivityPageTimerProps> = ({ timer }) => {
                   </div>
                 </div>
               </div>
-            );
-          })}
+            ))}
+          </div>
         </div>
       </div>
-      <div className="border-b border-gray-200 my-12" />
     </div>
   );
 };

--- a/components/ActivityPageTimer.tsx
+++ b/components/ActivityPageTimer.tsx
@@ -2,7 +2,7 @@
 
 import { FC, useState, useEffect, useRef } from "react";
 import { ActivityTimer, ActivityTimerTask } from "@/service/activity-timer/types";
-import { usePauseOrResumeActivityTimer, useCompleteActivityTask } from "@/service/activity-timer/hook";
+import { usePauseOrResumeActivityTimer } from "@/service/activity-timer/hook";
 import { TrialAction } from "@/service/payments/types";
 import { motion } from "framer-motion";
 import {
@@ -30,7 +30,6 @@ interface ActivityPageTimerProps {
 
 const ActivityPageTimer: FC<ActivityPageTimerProps> = ({ timer }) => {
   const { mutate: pauseOrPlay, isPending } = usePauseOrResumeActivityTimer();
-  const { mutate: completeTask, isPending: isCompletingTask } = useCompleteActivityTask();
   const [timeLeft, setTimeLeft] = useState(timer.remainingTime);
   const timerInitialized = useRef(false);
 
@@ -163,32 +162,19 @@ const ActivityPageTimer: FC<ActivityPageTimerProps> = ({ timer }) => {
                     </p>
                   </div>
                   <div className="flex items-center justify-center sm:justify-start mt-auto">
-                    <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
-                      {task.isCompleted ? (
-                        <button className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold transition-colors bg-green-600 text-white w-full sm:w-auto cursor-default">
-                          <CheckCircle2 className="w-4 h-4 mr-2" />
-                          Done
-                        </button>
-                      ) : (
-                        <>
-                          <Link
-                            href={task.url}
-                            className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold border border-orange-500 text-orange-500 hover:bg-orange-50 transition-colors w-full sm:w-auto"
-                          >
-                            Finish this activity
-                          </Link>
-                          <Button
-                            onClick={() => completeTask(task.key)}
-                            disabled={isCompletingTask}
-                            variant="outline"
-                            size="sm"
-                            className="text-xs border-green-600 text-green-600 hover:bg-green-50"
-                          >
-                            Mark as Done
-                          </Button>
-                        </>
-                      )}
-                    </div>
+                    {task.isCompleted ? (
+                      <button className="flex items-center justify-center px-4 py-2 rounded-lg text-sm font-semibold transition-colors bg-green-600 text-white w-full sm:w-auto cursor-default">
+                        <CheckCircle2 className="w-4 h-4 mr-2" />
+                        Done
+                      </button>
+                    ) : (
+                      <Link
+                        href={task.url}
+                        className="flex items-center justify-center sm:justify-start text-orange-500 hover:text-orange-400 font-medium text-sm w-full sm:w-auto"
+                      >
+                        Finish this activity
+                      </Link>
+                    )}
                   </div>
                 </div>
               </div>

--- a/components/SubscriptionCountdownTimer.tsx
+++ b/components/SubscriptionCountdownTimer.tsx
@@ -83,7 +83,7 @@ const SubscriptionCountdownTimer: React.FC<SubscriptionCountdownTimerProps> = ({
     const action = subscription.isPaused
       ? TrialAction.RESUME
       : TrialAction.PAUSE;
-    pauseOrPlay({ action });
+    pauseOrPlay({ action, timerId: subscription.id });
   };
 
   const timerComponents = Object.entries(timeLeft).map(([interval, value]) => (

--- a/components/TrialCountdownTimer.tsx
+++ b/components/TrialCountdownTimer.tsx
@@ -10,7 +10,7 @@ import {
   XCircleIcon,
   ChevronsRightLeft,
 } from 'lucide-react';
-import { usePauseOrPlay } from '@/service/payments/hook';
+import { usePauseOrResumeActivityTimer } from '@/service/activity-timer/hook';
 import {
   TrialAction,
 } from '@/service/payments/types';
@@ -44,7 +44,7 @@ const TrialCountdownTimer: React.FC<TrialCountdownTimerProps> = ({
   const remainingPauses = Math.max(0, maxPauses - pausesCount);
   const isPausable = remainingPauses > 0;
 
-  const { mutate: pauseOrPlay, isPending } = usePauseOrPlay();
+  const { mutate: pauseOrPlay, isPending } = usePauseOrResumeActivityTimer();
   const [timeLeft, setTimeLeft] = useState(remainingTime);
   const [isExpanded, setIsExpanded] = useState(false);
 

--- a/components/TrialCountdownTimer.tsx
+++ b/components/TrialCountdownTimer.tsx
@@ -12,10 +12,9 @@ import {
 } from 'lucide-react';
 import { usePauseOrPlay } from '@/service/payments/hook';
 import {
-  TrialStatusResponse,
   TrialAction,
-  TrialTasks,
 } from '@/service/payments/types';
+import { ActivityTimer } from '@/service/activity-timer/types';
 import { Button } from './ui/button';
 import {
   DropdownMenu,
@@ -25,19 +24,26 @@ import {
 } from './ui/dropdown-menu';
 
 interface TrialCountdownTimerProps {
-  trialStatus: TrialStatusResponse;
+  timer: ActivityTimer;
 }
 
 const TrialCountdownTimer: React.FC<TrialCountdownTimerProps> = ({
-  trialStatus,
+  timer,
 }) => {
   const {
     isPaused = false,
-    isTrialPausable = false,
-    remainingPauses = 0,
     remainingTime,
     tasks,
-  } = trialStatus;
+    type,
+    name
+  } = timer;
+
+  // Derive pause info since it's not directly in the new DTO but we have the pauses array
+  const maxPauses = 2;
+  const pausesCount = timer.pauses?.length || 0;
+  const remainingPauses = Math.max(0, maxPauses - pausesCount);
+  const isPausable = remainingPauses > 0;
+
   const { mutate: pauseOrPlay, isPending } = usePauseOrPlay();
   const [timeLeft, setTimeLeft] = useState(remainingTime);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -69,14 +75,6 @@ const TrialCountdownTimer: React.FC<TrialCountdownTimerProps> = ({
 
   const formattedTime = formatTime(timeLeft);
 
-  const taskLabels: Record<keyof TrialTasks, string> = {
-    createdBusiness: 'Create a business',
-    createdProductOrService: 'Create a product or service',
-    createdPromotion: 'Create a promotion',
-    createdOffer: 'Create an offer',
-    createdCoupon: 'Create a coupon',
-  };
-
   const timeUnits = Object.entries(formattedTime);
 
   return (
@@ -94,6 +92,7 @@ const TrialCountdownTimer: React.FC<TrialCountdownTimerProps> = ({
         <TimerIcon className="w-8 h-8 flex-shrink-0" />
         <div className="flex items-center space-x-2">
           <div className="flex flex-col items-center">
+            <span className="text-sm font-medium uppercase opacity-80">{type} TIMER</span>
             <span className="text-2xl font-bold">{formattedTime.days}</span>
             <span className="text-xs uppercase">days left</span>
           </div>
@@ -127,12 +126,13 @@ const TrialCountdownTimer: React.FC<TrialCountdownTimerProps> = ({
             <ChevronsRightLeft className="w-6 h-6" />
           </Button>
 
-          {isTrialPausable && (
+          {(isPausable || timer.isPaused) && (
             <div className="flex items-center space-x-2">
               <Button
                 onClick={() =>
                   pauseOrPlay({
                     action: isPaused ? TrialAction.RESUME : TrialAction.PAUSE,
+                    timerId: timer.id,
                   })
                 }
                 disabled={isPending || (!isPaused && remainingPauses <= 0)}
@@ -157,17 +157,20 @@ const TrialCountdownTimer: React.FC<TrialCountdownTimerProps> = ({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <p className="text-sm cursor-pointer hover:underline">
-              See your trial period tasks
+              See your tasks for {name}
             </p>
           </DropdownMenuTrigger>
           <DropdownMenuContent className="w-64 bg-gray-900 text-white">
-            {Object.entries(tasks).map(([key, completed]) => (
+            {tasks.map((task) => (
               <DropdownMenuItem
-                key={key}
+                key={task.key}
                 className="flex items-center justify-between"
               >
-                <span>{taskLabels[key as keyof TrialTasks]}</span>
-                {completed ? (
+                <div className="flex flex-col">
+                  <span className="font-semibold">{task.title}</span>
+                  <span className="text-xs opacity-70">{task.description}</span>
+                </div>
+                {task.isCompleted ? (
                   <CheckCircleIcon className="w-5 h-5 text-green-500" />
                 ) : (
                   <XCircleIcon className="w-5 h-5 text-red-500" />

--- a/service/activity-timer/hook.ts
+++ b/service/activity-timer/hook.ts
@@ -1,7 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import api from '../api';
 import { ActivityTimer } from './types';
 import { ErrorResponse } from '../listings/hook';
+import { TrialAction } from '../payments/types';
 
 export const useGetActivityTimers = () => {
   const fetch = async (): Promise<ActivityTimer[]> => {
@@ -23,4 +25,53 @@ export const useGetActivityTimers = () => {
     queryKey: ['FETCH_ACTIVITY_TIMERS'],
     enabled: true,
   });
+};
+
+export const usePauseOrResumeActivityTimer = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (payload: { action: TrialAction; timerId: string }) => {
+      const { action, timerId } = payload;
+      const endpoint =
+        action === TrialAction.PAUSE ? '/activity-timer/pause' : '/activity-timer/resume';
+      return api.post(endpoint, { timerId });
+    },
+    onSuccess: () => {
+      toast.success('Timer status updated successfully');
+      queryClient.invalidateQueries({ queryKey: ['FETCH_ACTIVITY_TIMERS'] });
+    },
+    onError: (error: unknown) => {
+      const err = error as ErrorResponse;
+      const errorMessage =
+        err.response?.data?.message ||
+        err.message ||
+        'Failed to update timer status';
+      toast.error(errorMessage);
+    },
+  });
+
+  return mutation;
+};
+
+export const useCompleteActivityTask = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (key: string) => {
+      return api.post(`/activity-timer/complete-task/${key}`);
+    },
+    onSuccess: () => {
+      toast.success('Task marked as completed');
+      queryClient.invalidateQueries({ queryKey: ['FETCH_ACTIVITY_TIMERS'] });
+    },
+    onError: (error: unknown) => {
+      const err = error as ErrorResponse;
+      const errorMessage =
+        err.response?.data?.message ||
+        err.message ||
+        'Failed to complete task';
+      toast.error(errorMessage);
+    },
+  });
+
+  return mutation;
 };

--- a/service/activity-timer/hook.ts
+++ b/service/activity-timer/hook.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '../api';
+import { ActivityTimer } from './types';
+import { ErrorResponse } from '../listings/hook';
+
+export const useGetActivityTimers = () => {
+  const fetch = async (): Promise<ActivityTimer[]> => {
+    try {
+      const response = await api.get('/activity-timer/status');
+      return response.data;
+    } catch (error: unknown) {
+      const err = error as ErrorResponse;
+      throw new Error(
+        err.response?.data?.message ||
+          err.message ||
+          'Failed to fetch activity timers'
+      );
+    }
+  };
+
+  return useQuery({
+    queryFn: fetch,
+    queryKey: ['FETCH_ACTIVITY_TIMERS'],
+    enabled: true,
+  });
+};

--- a/service/activity-timer/types.ts
+++ b/service/activity-timer/types.ts
@@ -1,0 +1,27 @@
+export interface ActivityTimerTask {
+  key: string;
+  url: string;
+  title: string;
+  description: string;
+  isCompleted: boolean;
+}
+
+export interface ActivityTimerPause {
+  pausedAt: string;
+  resumedAt: string | null;
+}
+
+export type ActivityTimerType = 'TRIAL' | 'GENERAL';
+
+export interface ActivityTimer {
+  id: string;
+  type: ActivityTimerType;
+  name: string;
+  description: string;
+  remainingTime: number;
+  tasks: ActivityTimerTask[];
+  isPaused: boolean;
+  pauses: ActivityTimerPause[];
+  expiresAt: string;
+  completedAt: string | null;
+}

--- a/service/payments/hook.ts
+++ b/service/payments/hook.ts
@@ -158,10 +158,10 @@ export const usePauseOrPlay = () => {
   const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: (payload: PauseResumeTrialDto) => {
-      const { action } = payload;
+      const { action, timerId } = payload;
       const endpoint =
         action === TrialAction.PAUSE ? '/trial/pause' : '/trial/resume';
-      return api.post(endpoint);
+      return api.post(endpoint, { timerId });
     },
     onSuccess: () => {
       toast.success('Trial status updated successfully');

--- a/service/payments/types.ts
+++ b/service/payments/types.ts
@@ -129,4 +129,5 @@ export enum TrialAction {
 
 export interface PauseResumeTrialDto {
   action: TrialAction;
+  timerId?: string;
 }


### PR DESCRIPTION
This change integrates the new activity timer status endpoint and separates the display of general and trial timers.
The floating header now specifically shows the 'GENERAL' timer if it exists.
The Activity Timer dashboard page now shows all other timers (e.g., 'TRIAL'), each with its own countdown timer and task list, preserving the original design.
Pause/Resume functionality has been updated to support targeting specific timers via their ID.
A UI bug was fixed where users could get stuck in a paused state if they used all their pause allocations.

---
*PR created automatically by Jules for task [6272370776502775791](https://jules.google.com/task/6272370776502775791) started by @Jahzeal*