### PR TITLE
Fix failing unit tests and builds in monorepo

### DIFF
--- a/apps/McomMall/service/user/types.ts
+++ b/apps/McomMall/service/user/types.ts
@@ -23,6 +23,7 @@ export interface User {
   voucher: boolean;
   promotion: boolean;
   coupons: boolean;
+  shippingAddresses?: any[]; // Allow shippingAddresses
 }
 
 export interface UpdateUserDto {

--- a/apps/mcom_mallAPI/src/resources/booking/booking.service.spec.ts
+++ b/apps/mcom_mallAPI/src/resources/booking/booking.service.spec.ts
@@ -21,6 +21,7 @@ import { CentralIntegrationService } from '../payments/services/central-integrat
 import { WalletService } from '../wallet/wallet.service';
 import { PaymentMethod } from '../order/entities/order-payment.entity';
 import { Business } from '../listings/entities/listing.entity';
+import { EmailService } from '../email/email.service';
 
 describe('BookingService', () => {
   let service: BookingService;
@@ -102,6 +103,16 @@ describe('BookingService', () => {
         {
           provide: CentralIntegrationService,
           useValue: { processCashback: jest.fn() },
+        },
+        {
+          provide: EmailService,
+          useValue: {
+            sendBookingConfirmation: jest.fn(),
+            sendBookingNotificationToBusiness: jest.fn(),
+            sendBookingCancellation: jest.fn(),
+            sendBookingUpdate: jest.fn(),
+            sendReviewRequest: jest.fn(),
+          },
         },
         {
           provide: WalletService,

--- a/apps/mcom_mallAPI/src/resources/group-circles/group-circles.service.spec.ts
+++ b/apps/mcom_mallAPI/src/resources/group-circles/group-circles.service.spec.ts
@@ -114,15 +114,30 @@ describe('GroupCirclesService', () => {
     it('should return discoverable circles excluding those owned or joined by the user', async () => {
       const user = { id: 'user-1' } as User;
       const circles = [
-        { id: 'group-1', founderId: 'user-1', members: [], founder: { firstName: 'Me' } }, // Owned by user
-        { id: 'group-2', founderId: 'user-2', members: [{ userId: 'user-1' }], founder: { firstName: 'Friend' } }, // User is a member
-        { id: 'group-3', founderId: 'user-3', members: [], founder: { firstName: 'Owner', lastName: '3' } }, // Valid
+        {
+          id: 'group-1',
+          founderId: 'user-1',
+          members: [],
+          founder: { firstName: 'Me' },
+        }, // Owned by user
+        {
+          id: 'group-2',
+          founderId: 'user-2',
+          members: [{ userId: 'user-1' }],
+          founder: { firstName: 'Friend' },
+        }, // User is a member
+        {
+          id: 'group-3',
+          founderId: 'user-3',
+          members: [],
+          founder: { firstName: 'Owner', lastName: '3' },
+        }, // Valid
       ] as any;
 
       jest.spyOn(groupRepo, 'find').mockResolvedValue(circles);
 
       const result = await service.discover(user);
-      
+
       // Expected behavior: Filter logic should remove group-1 and group-2
       expect(result.data).toHaveLength(1);
       expect(result.data[0].id).toBe('group-3');
@@ -132,26 +147,42 @@ describe('GroupCirclesService', () => {
       const user = { id: 'user-1' } as User;
       const userPostcode = 'SW1A 1AA';
       const circles = [
-        { 
-            id: 'group-far', founderId: 'user-2', members: [], 
-            founder: { firstName: 'A', lastName: 'B', businesses: [{ location: { postcode: 'M1 1AG' } }] } 
+        {
+          id: 'group-far',
+          founderId: 'user-2',
+          members: [],
+          founder: {
+            firstName: 'A',
+            lastName: 'B',
+            businesses: [{ location: { postcode: 'M1 1AG' } }],
+          },
         },
-        { 
-            id: 'group-exact', founderId: 'user-3', members: [], 
-            founder: { firstName: 'C', lastName: 'D', businesses: [{ location: { postcode: 'SW1A 1AA' } }] } 
+        {
+          id: 'group-exact',
+          founderId: 'user-3',
+          members: [],
+          founder: {
+            firstName: 'C',
+            lastName: 'D',
+            businesses: [{ location: { postcode: 'SW1A 1AA' } }],
+          },
         },
       ] as any;
 
       jest.spyOn(groupRepo, 'find').mockResolvedValue(circles);
-      jest.spyOn(geolocationService, 'getCoordinates').mockResolvedValue({ lat: 51.5, lng: -0.1 });
-      jest.spyOn(geolocationService, 'getBulkCoordinates').mockResolvedValue(new Map([
+      jest
+        .spyOn(geolocationService, 'getCoordinates')
+        .mockResolvedValue({ lat: 51.5, lng: -0.1 });
+      jest.spyOn(geolocationService, 'getBulkCoordinates').mockResolvedValue(
+        new Map([
           ['M1 1AG', { lat: 53.4, lng: -2.2 }],
-          ['SW1A 1AA', { lat: 51.5, lng: -0.1 }]
-      ]));
+          ['SW1A 1AA', { lat: 51.5, lng: -0.1 }],
+        ]),
+      );
       jest.spyOn(geolocationService, 'calculateDistance').mockReturnValue(262); // Distance for M1 1AG
 
       const result = await service.discover(user, userPostcode);
-      
+
       // Expected behavior: Exact string match on postcode gives priority 1
       expect(result.data[0].id).toBe('group-exact');
       expect(result.data[1].id).toBe('group-far');

--- a/apps/mcom_mallAPI/src/resources/group-circles/group-circles.service.ts
+++ b/apps/mcom_mallAPI/src/resources/group-circles/group-circles.service.ts
@@ -388,9 +388,13 @@ export class GroupCirclesService {
 
           if (circle.founderPostcode) {
             // Clean postcodes for comparison (remove spaces, uppercase)
-            const cleanUserPostcode = postcode.replace(/\s+/g, '').toUpperCase();
-            const cleanFounderPostcode = circle.founderPostcode.replace(/\s+/g, '').toUpperCase();
-            
+            const cleanUserPostcode = postcode
+              .replace(/\s+/g, '')
+              .toUpperCase();
+            const cleanFounderPostcode = circle.founderPostcode
+              .replace(/\s+/g, '')
+              .toUpperCase();
+
             if (cleanUserPostcode === cleanFounderPostcode) {
               distance = 0;
               isExactPostcodeMatch = true;

--- a/apps/mcom_mallAPI/test/group-circles.e2e-spec.ts
+++ b/apps/mcom_mallAPI/test/group-circles.e2e-spec.ts
@@ -166,9 +166,11 @@ describe('GroupCircles (e2e)', () => {
 
       expect(res.body.data).toBeDefined();
       expect(Array.isArray(res.body.data)).toBe(true);
-      
+
       // Verification: Ensure the user's own groups are not returned in discovery
-      const ownGroupsInResults = res.body.data.filter((g: any) => g.founderId === ownerJwtToken); // Token is a proxy here
+      const ownGroupsInResults = res.body.data.filter(
+        (g: any) => g.founderId === ownerJwtToken,
+      ); // Token is a proxy here
       expect(ownGroupsInResults.length).toBe(0);
     });
   });


### PR DESCRIPTION
This commit addresses the failing unit tests and builds in the `mcom-mall` workspace:
1.  **Fixed Unit Tests**: Added a missing `EmailService` mock to the `BookingService` test module within `@mcommall/api`.
2.  **Fixed Builds**: Addressed a TypeScript error (`shippingAddresses` missing from `User` interface) in `apps/McomMall/service/user/types.ts` that was preventing the dashboard app from building.
3.  **Run Actions**: Successfully executed `pnpm run build`, verified all unit tests passing with `pnpm --filter @mcommall/api test`, and manually triggered lint scripts.

---
*PR created automatically by Jules for task [17612738264681481606](https://jules.google.com/task/17612738264681481606) started by @Azeem-py*