### PR TITLE
feat(api): implement 3-tier campaign cashback system

### DIFF
--- a/apps/mcom_mallAPI/scripts/create-test-db.ts
+++ b/apps/mcom_mallAPI/scripts/create-test-db.ts
@@ -1,4 +1,3 @@
-
 import { Client } from 'pg';
 import * as dotenv from 'dotenv';
 import * as path from 'path';
@@ -26,17 +25,20 @@ async function createTestDb() {
   try {
     await client.connect();
 
-    const res = await client.query(
-      `SELECT datname FROM pg_catalog.pg_database WHERE datname = '${dbName}'`
-    );
+    // Kill all connections to the test database
+    await client.query(`
+      SELECT pg_terminate_backend(pg_stat_activity.pid)
+      FROM pg_stat_activity
+      WHERE pg_stat_activity.datname = '${dbName}'
+        AND pid <> pg_backend_pid();
+    `);
 
-    if (res.rowCount === 0) {
-      console.log(`Database "${dbName}" does not exist. Creating...`);
-      await client.query(`CREATE DATABASE "${dbName}"`);
-      console.log(`Database "${dbName}" created successfully.`);
-    } else {
-      console.log(`Database "${dbName}" already exists.`);
-    }
+    console.log(`Dropping database "${dbName}"...`);
+    await client.query(`DROP DATABASE IF EXISTS "${dbName}"`);
+    
+    console.log(`Creating database "${dbName}"...`);
+    await client.query(`CREATE DATABASE "${dbName}"`);
+    console.log(`Database "${dbName}" created successfully.`);
   } catch (err) {
     console.error('Error creating test database:', err);
     process.exit(1);

--- a/apps/mcom_mallAPI/src/app.module.ts
+++ b/apps/mcom_mallAPI/src/app.module.ts
@@ -48,6 +48,7 @@ import { ProvisionModule } from './resources/provision/provision.module';
 import { ShippingAddressModule } from './resources/shipping-address/shipping-address.module';
 import { HelpRequestsModule } from './help-requests/help-requests.module';
 import { TerminalCashbackModule } from './resources/terminal-cashback/terminal-cashback.module';
+import { CampaignCashbackModule } from './resources/campaign-cashback/campaign-cashback.module';
 import { ActivityTimerModule } from './resources/activity-timer/activity-timer.module';
 import { ActivityTimerGuard } from './resources/activity-timer/activity-timer.guard';
 import { SupportTicketsModule } from './resources/support-tickets/support-tickets.module';
@@ -111,6 +112,7 @@ import { DigitalValueModule } from './resources/digital-value/digital-value.modu
     VoucherModule,
     ExchangeModule,
     TerminalCashbackModule,
+    CampaignCashbackModule,
     SeasonsModule,
   ],
   controllers: [AppController],

--- a/apps/mcom_mallAPI/src/database/migrations/1772526556085-AddCampaignCashbackSystem.ts
+++ b/apps/mcom_mallAPI/src/database/migrations/1772526556085-AddCampaignCashbackSystem.ts
@@ -1,0 +1,299 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCampaignCashbackSystem1772526556085 implements MigrationInterface {
+  name = 'AddCampaignCashbackSystem1772526556085';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "FK_81d38487c29d69bf340eead614c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "FK_f143f396ea55404f8ed5a5421a3"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."campaign_cashbacks_type_enum" AS ENUM('REGULAR', 'SEASONAL')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."campaign_cashbacks_targettype_enum" AS ENUM('CONSUMERS', 'BUSINESS')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."campaign_cashbacks_displaytype_enum" AS ENUM('VOUCHER', 'E_CARD')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."campaign_cashbacks_unlockmode_enum" AS ENUM('REQUIRE_FULL_UNLOCK', 'ALLOW_PRELOADED_USAGE')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "campaign_cashbacks" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "name" character varying NOT NULL, "type" "public"."campaign_cashbacks_type_enum" NOT NULL DEFAULT 'REGULAR', "startDate" TIMESTAMP NOT NULL, "endDate" TIMESTAMP NOT NULL, "targetType" "public"."campaign_cashbacks_targettype_enum" NOT NULL DEFAULT 'CONSUMERS', "displayType" "public"."campaign_cashbacks_displaytype_enum" NOT NULL DEFAULT 'VOUCHER', "totalValue" numeric(10,2) NOT NULL, "levelValue" numeric(10,2) NOT NULL, "unlockMode" "public"."campaign_cashbacks_unlockmode_enum" NOT NULL DEFAULT 'REQUIRE_FULL_UNLOCK', "expiryDate" TIMESTAMP NOT NULL, "activationTimerDays" integer NOT NULL DEFAULT '0', "activationTasks" text, "externalCampaign" boolean NOT NULL DEFAULT false, "externalRedemptionUrl" character varying, "value1Title" character varying NOT NULL, "value1Description" text NOT NULL, "value1UsageText" character varying NOT NULL, "value1Channels" text, "value1UsageTypes" text, "value2Title" character varying NOT NULL, "value2Description" text NOT NULL, "value2UsageText" character varying NOT NULL, "value2Channels" text, "value2UsageTypes" text, "value3Title" character varying NOT NULL, "value3Description" text NOT NULL, "value3UsageText" character varying NOT NULL, "value3Channels" text, "value3UsageTypes" text, "selectAll" boolean NOT NULL DEFAULT true, "targetIds" text, "seasonId" uuid, CONSTRAINT "PK_9ea1400851096de3ae3e546235f" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."user_campaign_cashbacks_status_enum" AS ENUM('NOT_ACTIVE', 'LOCKED', 'ACTIVE', 'PARTIALLY_USED', 'FULLY_USED', 'EXPIRED')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_campaign_cashbacks" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "status" "public"."user_campaign_cashbacks_status_enum" NOT NULL DEFAULT 'ACTIVE', "contributionPaid" boolean NOT NULL DEFAULT false, "activationTimerDate" TIMESTAMP, "userId" uuid, "campaignId" uuid, CONSTRAINT "PK_ef467e39a60125a173b92cfc507" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."user_campaign_wallets_channeltype_enum" AS ENUM('HYPERLOCAL', 'NEARBY', 'ONLINE')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_campaign_wallets" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "deleted_at" TIMESTAMP, "channelType" "public"."user_campaign_wallets_channeltype_enum" NOT NULL, "value1Balance" numeric(10,2) NOT NULL DEFAULT '0', "value2Balance" numeric(10,2) NOT NULL DEFAULT '0', "value3Balance" numeric(10,2) NOT NULL DEFAULT '0', "userCampaignId" uuid, CONSTRAINT "PK_e1f07f492b2e6989566a37a8d2b" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "skills"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "serviceArea"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "portfolio"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "UQ_81d38487c29d69bf340eead614c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "userId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "bookingUrl"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "fixedPriceFrom"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "hourlyRateFrom"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "quoteOnly"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "hasPublicLiabilityInsurance"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "insuranceProvider"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "insuranceExpiryDate"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "UQ_f143f396ea55404f8ed5a5421a3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "businessId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "bookingUrl" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "fixedPriceFrom" numeric(10,2)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "hourlyRateFrom" numeric(10,2)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "quoteOnly" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "hasPublicLiabilityInsurance" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "insuranceProvider" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "insuranceExpiryDate" date`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "businessId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "UQ_f143f396ea55404f8ed5a5421a3" UNIQUE ("businessId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "skills" text`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "serviceArea" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "portfolio" text`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "userId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "UQ_81d38487c29d69bf340eead614c" UNIQUE ("userId")`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."wallet_transactions_type_enum" RENAME TO "wallet_transactions_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."wallet_transactions_type_enum" AS ENUM('earning_order', 'earning_gift_card', 'earning_voucher', 'earning_coupon', 'earning_terminal_cashback', 'earning_booking', 'booking_payment_released', 'withdrawal', 'spend', 'funding', 'adjustment', 'campaign_cashback_contribution')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "wallet_transactions" ALTER COLUMN "type" TYPE "public"."wallet_transactions_type_enum" USING "type"::"text"::"public"."wallet_transactions_type_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."wallet_transactions_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "FK_f143f396ea55404f8ed5a5421a3" FOREIGN KEY ("businessId") REFERENCES "businesses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "FK_81d38487c29d69bf340eead614c" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaign_cashbacks" ADD CONSTRAINT "FK_a9450aef7215d4a4a846d45bc17" FOREIGN KEY ("seasonId") REFERENCES "seasons"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_campaign_cashbacks" ADD CONSTRAINT "FK_a44db07fb5f879b18daf47b5814" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_campaign_cashbacks" ADD CONSTRAINT "FK_919d54488197c903bf28a1c72ab" FOREIGN KEY ("campaignId") REFERENCES "campaign_cashbacks"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_campaign_wallets" ADD CONSTRAINT "FK_c0cb4a32da4f7d7b1519dbcd043" FOREIGN KEY ("userCampaignId") REFERENCES "user_campaign_cashbacks"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user_campaign_wallets" DROP CONSTRAINT "FK_c0cb4a32da4f7d7b1519dbcd043"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_campaign_cashbacks" DROP CONSTRAINT "FK_919d54488197c903bf28a1c72ab"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_campaign_cashbacks" DROP CONSTRAINT "FK_a44db07fb5f879b18daf47b5814"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "campaign_cashbacks" DROP CONSTRAINT "FK_a9450aef7215d4a4a846d45bc17"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "FK_81d38487c29d69bf340eead614c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "FK_f143f396ea55404f8ed5a5421a3"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."wallet_transactions_type_enum_old" AS ENUM('earning_order', 'earning_gift_card', 'earning_voucher', 'earning_coupon', 'earning_terminal_cashback', 'earning_booking', 'booking_payment_released', 'withdrawal', 'spend', 'funding', 'adjustment')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "wallet_transactions" ALTER COLUMN "type" TYPE "public"."wallet_transactions_type_enum_old" USING "type"::"text"::"public"."wallet_transactions_type_enum_old"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."wallet_transactions_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."wallet_transactions_type_enum_old" RENAME TO "wallet_transactions_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "UQ_81d38487c29d69bf340eead614c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "userId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "portfolio"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "serviceArea"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "skills"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "UQ_f143f396ea55404f8ed5a5421a3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "businessId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "insuranceExpiryDate"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "insuranceProvider"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "hasPublicLiabilityInsurance"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "quoteOnly"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "hourlyRateFrom"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "fixedPriceFrom"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" DROP COLUMN "bookingUrl"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "businessId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "UQ_f143f396ea55404f8ed5a5421a3" UNIQUE ("businessId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "insuranceExpiryDate" date`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "insuranceProvider" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "hasPublicLiabilityInsurance" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "quoteOnly" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "hourlyRateFrom" numeric(10,2)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "fixedPriceFrom" numeric(10,2)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "bookingUrl" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "userId" uuid`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "UQ_81d38487c29d69bf340eead614c" UNIQUE ("userId")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "portfolio" text`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "serviceArea" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD "skills" text`,
+    );
+    await queryRunner.query(`DROP TABLE "user_campaign_wallets"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."user_campaign_wallets_channeltype_enum"`,
+    );
+    await queryRunner.query(`DROP TABLE "user_campaign_cashbacks"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."user_campaign_cashbacks_status_enum"`,
+    );
+    await queryRunner.query(`DROP TABLE "campaign_cashbacks"`);
+    await queryRunner.query(
+      `DROP TYPE "public"."campaign_cashbacks_unlockmode_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."campaign_cashbacks_displaytype_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."campaign_cashbacks_targettype_enum"`,
+    );
+    await queryRunner.query(
+      `DROP TYPE "public"."campaign_cashbacks_type_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "FK_f143f396ea55404f8ed5a5421a3" FOREIGN KEY ("businessId") REFERENCES "businesses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "FK_81d38487c29d69bf340eead614c" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/apps/mcom_mallAPI/src/database/migrations/1772528091725-UpdateCampaignAudienceTargeting.ts
+++ b/apps/mcom_mallAPI/src/database/migrations/1772528091725-UpdateCampaignAudienceTargeting.ts
@@ -1,0 +1,88 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateCampaignAudienceTargeting1772528091725 implements MigrationInterface {
+    name = 'UpdateCampaignAudienceTargeting1772528091725'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "FK_81d38487c29d69bf340eead614c"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "FK_f143f396ea55404f8ed5a5421a3"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "skills"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "serviceArea"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "portfolio"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "UQ_81d38487c29d69bf340eead614c"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "userId"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "bookingUrl"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "fixedPriceFrom"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "hourlyRateFrom"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "quoteOnly"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "hasPublicLiabilityInsurance"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "insuranceProvider"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "insuranceExpiryDate"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "UQ_f143f396ea55404f8ed5a5421a3"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "businessId"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "bookingUrl" character varying`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "fixedPriceFrom" numeric(10,2)`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "hourlyRateFrom" numeric(10,2)`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "quoteOnly" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "hasPublicLiabilityInsurance" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "insuranceProvider" character varying`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "insuranceExpiryDate" date`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "businessId" uuid`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "UQ_f143f396ea55404f8ed5a5421a3" UNIQUE ("businessId")`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "skills" text`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "serviceArea" character varying`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "portfolio" text`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "userId" uuid`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "UQ_81d38487c29d69bf340eead614c" UNIQUE ("userId")`);
+        await queryRunner.query(`ALTER TYPE "public"."campaign_cashbacks_targettype_enum" RENAME TO "campaign_cashbacks_targettype_enum_old"`);
+        await queryRunner.query(`CREATE TYPE "public"."campaign_cashbacks_targettype_enum" AS ENUM('CUSTOMER', 'BUSINESS', 'ALL', 'SPECIFIC_USERS')`);
+        await queryRunner.query(`ALTER TABLE "campaign_cashbacks" ALTER COLUMN "targetType" DROP DEFAULT`);
+        await queryRunner.query(`ALTER TABLE "campaign_cashbacks" ALTER COLUMN "targetType" TYPE "public"."campaign_cashbacks_targettype_enum" USING "targetType"::"text"::"public"."campaign_cashbacks_targettype_enum"`);
+        await queryRunner.query(`ALTER TABLE "campaign_cashbacks" ALTER COLUMN "targetType" SET DEFAULT 'CUSTOMER'`);
+        await queryRunner.query(`DROP TYPE "public"."campaign_cashbacks_targettype_enum_old"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "FK_f143f396ea55404f8ed5a5421a3" FOREIGN KEY ("businessId") REFERENCES "businesses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "FK_81d38487c29d69bf340eead614c" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "FK_81d38487c29d69bf340eead614c"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "FK_f143f396ea55404f8ed5a5421a3"`);
+        await queryRunner.query(`CREATE TYPE "public"."campaign_cashbacks_targettype_enum_old" AS ENUM('CONSUMERS', 'BUSINESS')`);
+        await queryRunner.query(`ALTER TABLE "campaign_cashbacks" ALTER COLUMN "targetType" DROP DEFAULT`);
+        await queryRunner.query(`ALTER TABLE "campaign_cashbacks" ALTER COLUMN "targetType" TYPE "public"."campaign_cashbacks_targettype_enum_old" USING "targetType"::"text"::"public"."campaign_cashbacks_targettype_enum_old"`);
+        await queryRunner.query(`ALTER TABLE "campaign_cashbacks" ALTER COLUMN "targetType" SET DEFAULT 'CONSUMERS'`);
+        await queryRunner.query(`DROP TYPE "public"."campaign_cashbacks_targettype_enum"`);
+        await queryRunner.query(`ALTER TYPE "public"."campaign_cashbacks_targettype_enum_old" RENAME TO "campaign_cashbacks_targettype_enum"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "UQ_81d38487c29d69bf340eead614c"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "userId"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "portfolio"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "serviceArea"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "skills"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP CONSTRAINT "UQ_f143f396ea55404f8ed5a5421a3"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "businessId"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "insuranceExpiryDate"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "insuranceProvider"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "hasPublicLiabilityInsurance"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "quoteOnly"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "hourlyRateFrom"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "fixedPriceFrom"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" DROP COLUMN "bookingUrl"`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "businessId" uuid`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "UQ_f143f396ea55404f8ed5a5421a3" UNIQUE ("businessId")`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "insuranceExpiryDate" date`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "insuranceProvider" character varying`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "hasPublicLiabilityInsurance" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "quoteOnly" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "hourlyRateFrom" numeric(10,2)`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "fixedPriceFrom" numeric(10,2)`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "bookingUrl" character varying`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "userId" uuid`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "UQ_81d38487c29d69bf340eead614c" UNIQUE ("userId")`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "portfolio" text`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "serviceArea" character varying`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD "skills" text`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "FK_f143f396ea55404f8ed5a5421a3" FOREIGN KEY ("businessId") REFERENCES "businesses"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "service_provider_profiles" ADD CONSTRAINT "FK_81d38487c29d69bf340eead614c" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
+    }
+
+}

--- a/apps/mcom_mallAPI/src/resources/booking/dto/create-booking.dto.ts
+++ b/apps/mcom_mallAPI/src/resources/booking/dto/create-booking.dto.ts
@@ -51,4 +51,8 @@ export class CreateBookingDto {
 
   @IsOptional()
   config?: Record<string, any>;
+
+  @IsOptional()
+  @IsUUID()
+  campaignCashbackId?: string;
 }

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.controller.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.controller.ts
@@ -1,0 +1,173 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  UseGuards,
+  Query,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { CampaignCashbackService } from './campaign-cashback.service';
+import { CreateCampaignCashbackDto } from './dto/create-campaign-cashback.dto';
+import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../../common/guards/roles.guard';
+import { Roles } from '../../common/decorators/roles.decorator';
+import { UserRole } from '../../common/role.enum';
+import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+import { CampaignTargetType } from './campaign-cashback.enum';
+import { ContributeDto } from './dto/contribute.dto';
+
+@ApiTags('Campaign Cashback')
+@ApiBearerAuth()
+@Controller('campaign-cashback')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class CampaignCashbackController {
+  constructor(private readonly service: CampaignCashbackService) {}
+
+  @Post()
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Create a new campaign cashback template',
+    description:
+      'Endpoint for Platform Admins to setup a new 3-tier cashback campaign. Defines values, spending channels, and inheritance (Regular/Seasonal).',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Campaign created successfully',
+    schema: {
+      example: {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        name: 'Spring 2026 Promo',
+        totalValue: 30,
+        levelValue: 10,
+        type: 'REGULAR',
+        startDate: '2026-03-01T00:00:00Z',
+        endDate: '2026-04-01T23:59:59Z',
+      },
+    },
+  })
+  create(@Body() createDto: CreateCampaignCashbackDto) {
+    return this.service.create(createDto);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get all eligible campaign cards for the current user',
+    description:
+      "Returns all campaign cards available to the logged-in user. If a campaign is seen for the first time, it automatically initializes the user's multi-bucket wallet instances.",
+  })
+  @ApiQuery({
+    name: 'targetType',
+    enum: CampaignTargetType,
+    required: false,
+    description: 'Filter by B2B (BUSINESS) or B2C (CONSUMERS)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of user campaign instances with current balances',
+    schema: {
+      example: [
+        {
+          id: 'user-campaign-uuid',
+          status: 'ACTIVE',
+          contributionPaid: false,
+          campaign: { name: 'Spring 2026 Promo', totalValue: 30 },
+          wallets: [
+            {
+              channelType: 'ONLINE',
+              value1Balance: 10,
+              value2Balance: 0,
+              value3Balance: 0,
+            },
+            {
+              channelType: 'HYPERLOCAL',
+              value1Balance: 0,
+              value2Balance: 10,
+              value3Balance: 0,
+            },
+          ],
+        },
+      ],
+    },
+  })
+  findAll(
+    @CurrentUser() user: User,
+    @Query('targetType') targetType?: CampaignTargetType,
+  ) {
+    return this.service.findAllForUser(user, targetType);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get detailed status of a specific campaign card',
+    description:
+      'Retrieve the configuration, balances, and contribution status of a single campaign card.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the User Campaign instance',
+  })
+  @ApiResponse({ status: 200, description: 'Detailed user campaign object' })
+  findOne(@Param('id') id: string, @CurrentUser() user: User) {
+    return this.service.findOne(id, user);
+  }
+
+  @Post(':id/contribute')
+  @ApiOperation({
+    summary: 'Process user contribution to unlock full card value',
+    description:
+      'Allows a user to pay their 1/3 share (£10 in a £30 model) using Wallet, Stripe, or PayPal. Includes idempotency checks to prevent duplicate charges.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the User Campaign instance',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Contribution successful, card unlocked',
+    schema: {
+      example: {
+        id: 'user-campaign-uuid',
+        contributionPaid: true,
+        status: 'ACTIVE',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Insufficient funds or duplicate transaction ID',
+  })
+  contribute(
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+    @Body() contributeDto: ContributeDto,
+  ) {
+    return this.service.contribute(id, user, contributeDto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Delete a campaign template',
+    description:
+      'Admin-only endpoint to remove a campaign template from the system.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'The UUID of the Campaign Cashback template',
+  })
+  @ApiResponse({ status: 200, description: 'Campaign deleted successfully' })
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.enum.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.enum.ts
@@ -1,0 +1,46 @@
+export enum CampaignTargetType {
+  CUSTOMER = 'CUSTOMER',
+  BUSINESS = 'BUSINESS',
+  ALL = 'ALL',
+  SPECIFIC_USERS = 'SPECIFIC_USERS',
+}
+
+export enum CampaignDisplayType {
+  VOUCHER = 'VOUCHER',
+  E_CARD = 'E_CARD',
+}
+
+export enum CampaignUnlockMode {
+  REQUIRE_FULL_UNLOCK = 'REQUIRE_FULL_UNLOCK',
+  ALLOW_PRELOADED_USAGE = 'ALLOW_PRELOADED_USAGE',
+}
+
+export enum CampaignStatus {
+  NOT_ACTIVE = 'NOT_ACTIVE',
+  LOCKED = 'LOCKED',
+  ACTIVE = 'ACTIVE',
+  PARTIALLY_USED = 'PARTIALLY_USED',
+  FULLY_USED = 'FULLY_USED',
+  EXPIRED = 'EXPIRED',
+}
+
+export enum SpendingChannel {
+  HYPERLOCAL = 'HYPERLOCAL',
+  NEARBY = 'NEARBY',
+  ONLINE = 'ONLINE',
+}
+
+export enum CampaignCategory {
+  REGULAR = 'REGULAR',
+  SEASONAL = 'SEASONAL',
+}
+
+export enum CampaignUsageType {
+  ORDER_PRODUCT = 'ORDER_PRODUCT',
+  BOOK_SERVICE = 'BOOK_SERVICE',
+  BUY_GIFT_CARD = 'BUY_GIFT_CARD',
+  BUY_VOUCHER = 'BUY_VOUCHER',
+  BUY_DIGITAL_VALUE = 'BUY_DIGITAL_VALUE',
+  EXCHANGE_ITEM = 'EXCHANGE_ITEM',
+  ANYWHERE = 'ANYWHERE',
+}

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.module.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.module.ts
@@ -1,0 +1,29 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CampaignCashbackController } from './campaign-cashback.controller';
+import { CampaignCashbackService } from './campaign-cashback.service';
+import { CampaignCashback } from './entities/campaign-cashback.entity';
+import { UserCampaignCashback } from './entities/user-campaign-cashback.entity';
+import { UserCampaignWallet } from './entities/user-campaign-wallet.entity';
+import { Season } from '../seasons/entities/season.entity';
+import { WalletModule } from '../wallet/wallet.module';
+import { PaymentsModule } from '../payments/payments.module';
+import { OrderPayment } from '../order/entities/order-payment.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      CampaignCashback,
+      UserCampaignCashback,
+      UserCampaignWallet,
+      Season,
+      OrderPayment,
+    ]),
+    forwardRef(() => WalletModule),
+    PaymentsModule,
+  ],
+  controllers: [CampaignCashbackController],
+  providers: [CampaignCashbackService],
+  exports: [CampaignCashbackService],
+})
+export class CampaignCashbackModule {}

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.service.spec.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.service.spec.ts
@@ -1,0 +1,347 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CampaignCashbackService } from './campaign-cashback.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CampaignCashback } from './entities/campaign-cashback.entity';
+import { UserCampaignCashback } from './entities/user-campaign-cashback.entity';
+import { UserCampaignWallet } from './entities/user-campaign-wallet.entity';
+import { Repository, DataSource } from 'typeorm';
+import {
+  CampaignUnlockMode,
+  SpendingChannel,
+  CampaignCategory,
+  CampaignUsageType,
+  CampaignTargetType,
+} from './campaign-cashback.enum';
+import { BadRequestException } from '@nestjs/common';
+import { Season } from '../seasons/entities/season.entity';
+import { WalletService } from '../wallet/wallet.service';
+import { PaymentProviderService } from '../payments/services/payment-provider.service';
+import { ContributionPaymentProvider } from './dto/contribute.dto';
+import { OrderPayment } from '../order/entities/order-payment.entity';
+import { UserRole } from '../../common/role.enum';
+
+const mockRepository = () => ({
+  create: jest.fn((entity) => entity),
+  save: jest.fn((entity) => Promise.resolve({ ...entity, id: 'uuid' })),
+  findOne: jest.fn(),
+  find: jest.fn(),
+  remove: jest.fn(),
+});
+
+const mockWalletService = () => ({
+  spendBalance: jest.fn(),
+});
+
+const mockPaymentProviderService = () => ({
+  verifyStripePaymentIntent: jest.fn(),
+  captureAndVerifyPaypalOrder: jest.fn(),
+});
+
+const mockDataSource = () => ({
+  transaction: jest.fn((cb) =>
+    cb({
+      findOne: jest.fn(),
+      create: jest.fn((entity) => entity),
+      save: jest.fn((entity) => Promise.resolve(entity)),
+      getRepository: jest.fn(),
+    }),
+  ),
+});
+
+describe('CampaignCashbackService', () => {
+  let service: CampaignCashbackService;
+  let userCampaignRepo: Repository<UserCampaignCashback>;
+  let orderPaymentRepo: Repository<OrderPayment>;
+  let seasonRepo: Repository<Season>;
+  let walletService: WalletService;
+  let paymentProviderService: PaymentProviderService;
+  let dataSource: DataSource;
+  let campaignRepo: Repository<CampaignCashback>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CampaignCashbackService,
+        {
+          provide: getRepositoryToken(CampaignCashback),
+          useFactory: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(UserCampaignCashback),
+          useFactory: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(UserCampaignWallet),
+          useFactory: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(Season),
+          useFactory: mockRepository,
+        },
+        {
+          provide: getRepositoryToken(OrderPayment),
+          useFactory: mockRepository,
+        },
+        { provide: WalletService, useFactory: mockWalletService },
+        {
+          provide: PaymentProviderService,
+          useFactory: mockPaymentProviderService,
+        },
+        { provide: DataSource, useFactory: mockDataSource },
+      ],
+    }).compile();
+
+    service = module.get<CampaignCashbackService>(CampaignCashbackService);
+    userCampaignRepo = module.get(getRepositoryToken(UserCampaignCashback));
+    orderPaymentRepo = module.get(getRepositoryToken(OrderPayment));
+    seasonRepo = module.get(getRepositoryToken(Season));
+    walletService = module.get<WalletService>(WalletService);
+    paymentProviderService = module.get<PaymentProviderService>(
+      PaymentProviderService,
+    );
+    dataSource = module.get<DataSource>(DataSource);
+    campaignRepo = module.get(getRepositoryToken(CampaignCashback));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create (Logic & Validation)', () => {
+    it('should correctly calculate the 1/3 level value (£30 -> £10)', async () => {
+      const dto: any = {
+        name: 'Test Split',
+        totalValue: 30,
+        type: CampaignCategory.REGULAR,
+        startDate: new Date().toISOString(),
+        endDate: new Date().toISOString(),
+      };
+
+      const result = await service.create(dto);
+      expect(result.levelValue).toBe(10); // 30 / 3
+    });
+
+    it('should inherit dates from a Season for seasonal campaigns', async () => {
+      const mockSeason = {
+        id: 's1',
+        startDate: new Date('2026-06-01'),
+        endDate: new Date('2026-08-31'),
+      };
+      const dto: any = {
+        name: 'Summer Sale',
+        type: CampaignCategory.SEASONAL,
+        seasonId: 's1',
+        totalValue: 30,
+      };
+
+      jest.spyOn(seasonRepo, 'findOne').mockResolvedValue(mockSeason as any);
+
+      const result = await service.create(dto);
+      expect(result.startDate).toEqual(mockSeason.startDate);
+      expect(result.endDate).toEqual(mockSeason.endDate);
+    });
+  });
+
+  describe('findAllForUser (Targeting Logic)', () => {
+    const now = new Date();
+    const mockUser: any = { id: 'u1', role: UserRole.CUSTOMER };
+    const mockCampaign = {
+      id: 'c1',
+      name: 'All Audience',
+      targetType: CampaignTargetType.ALL,
+      startDate: new Date(now.getTime() - 10000),
+      endDate: new Date(now.getTime() + 10000),
+      levelValue: 10,
+    };
+
+    it('should return campaign for ALL audience', async () => {
+      jest.spyOn(campaignRepo, 'find').mockResolvedValue([mockCampaign as any]);
+      jest.spyOn(userCampaignRepo, 'findOne').mockResolvedValue(null);
+      jest.spyOn(userCampaignRepo, 'save').mockImplementation(async (c) => c as any);
+
+      const result = await service.findAllForUser(mockUser);
+      expect(result).toHaveLength(1);
+      expect(result[0].campaign.targetType).toBe(CampaignTargetType.ALL);
+    });
+
+    it('should filter out BUSINESS campaigns for CUSTOMER role', async () => {
+      const bizCampaign = { ...mockCampaign, targetType: CampaignTargetType.BUSINESS };
+      jest.spyOn(campaignRepo, 'find').mockResolvedValue([bizCampaign as any]);
+
+      const result = await service.findAllForUser(mockUser);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('contribute (Security & Idempotency)', () => {
+    let mockUser: any;
+    let mockCampaign: any;
+
+    beforeEach(() => {
+      mockUser = { id: 'u1' };
+      mockCampaign = {
+        id: 'uc1',
+        contributionPaid: false,
+        campaign: { levelValue: 10, name: 'Promo' },
+      };
+    });
+
+    it('should throw error if transactionId was already processed (Stripe/PayPal)', async () => {
+      jest.spyOn(userCampaignRepo, 'findOne').mockResolvedValue(mockCampaign);
+      jest
+        .spyOn(orderPaymentRepo, 'findOne')
+        .mockResolvedValue({ id: 'p1' } as any);
+
+      await expect(
+        service.contribute('uc1', mockUser, {
+          amount: 10,
+          paymentMethod: ContributionPaymentProvider.STRIPE,
+          transactionId: 'already_used',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should invoke external verification BEFORE the database lock', async () => {
+      jest.spyOn(userCampaignRepo, 'findOne').mockResolvedValue(mockCampaign);
+      jest.spyOn(orderPaymentRepo, 'findOne').mockResolvedValue(null);
+      jest
+        .spyOn(paymentProviderService, 'verifyStripePaymentIntent')
+        .mockResolvedValue({ ok: true } as any);
+
+      const mockManager = {
+        findOne: jest.fn().mockImplementation((entity) => {
+          if (entity === UserCampaignCashback)
+            return Promise.resolve(mockCampaign);
+          return Promise.resolve(null);
+        }),
+        save: jest.fn().mockImplementation(async (entity) => entity),
+        create: jest.fn((entity) => entity),
+      };
+
+      const txSpy = jest
+        .spyOn(dataSource, 'transaction')
+        .mockImplementation(async (arg1: any, arg2?: any) => {
+          const cb = typeof arg1 === 'function' ? arg1 : arg2;
+          return cb(mockManager);
+        });
+
+      await service.contribute('uc1', mockUser, {
+        amount: 10,
+        paymentMethod: ContributionPaymentProvider.STRIPE,
+        transactionId: 'valid_tx',
+      });
+
+      expect(
+        paymentProviderService.verifyStripePaymentIntent,
+      ).toHaveBeenCalled();
+      expect(txSpy).toHaveBeenCalled();
+    });
+
+    it('should use pessimistic_write lock during the critical update section', async () => {
+      jest.spyOn(userCampaignRepo, 'findOne').mockResolvedValue(mockCampaign);
+      jest.spyOn(walletService, 'spendBalance').mockResolvedValue({} as any);
+
+      const mockManager = {
+        findOne: jest.fn().mockResolvedValue(mockCampaign),
+        save: jest.fn().mockResolvedValue(mockCampaign),
+      };
+
+      jest
+        .spyOn(dataSource, 'transaction')
+        .mockImplementation(async (arg1: any, arg2?: any) => {
+          const cb = typeof arg1 === 'function' ? arg1 : arg2;
+          return cb(mockManager);
+        });
+
+      await service.contribute('uc1', mockUser, {
+        amount: 10,
+        paymentMethod: ContributionPaymentProvider.WALLET,
+      });
+
+      expect(mockManager.findOne).toHaveBeenCalledWith(
+        UserCampaignCashback,
+        expect.objectContaining({
+          lock: { mode: 'pessimistic_write' },
+        }),
+      );
+    });
+  });
+
+  describe('spend (Manual Deduction Logic)', () => {
+    let mockUser: any;
+    const now = new Date();
+    const startDate = new Date(now.getTime() - 10000);
+    const endDate = new Date(now.getTime() + 10000);
+
+    beforeEach(() => {
+      mockUser = { id: 'u1' };
+    });
+
+    it('should deduct from Value 1 then Value 2 buckets sequentially', async () => {
+      const mockCampaign = {
+        startDate,
+        endDate,
+        unlockMode: CampaignUnlockMode.ALLOW_PRELOADED_USAGE,
+        value1UsageTypes: [CampaignUsageType.ORDER_PRODUCT],
+        value2UsageTypes: [CampaignUsageType.ORDER_PRODUCT],
+        value3UsageTypes: [CampaignUsageType.ANYWHERE],
+      };
+
+      const mockWallet = {
+        channelType: SpendingChannel.ONLINE,
+        value1Balance: 10,
+        value2Balance: 10,
+        value3Balance: 10,
+      };
+
+      const mockUserCampaign = {
+        id: 'uc1',
+        campaign: mockCampaign,
+        wallets: [mockWallet],
+        contributionPaid: false,
+      };
+
+      const mockManager = {
+        findOne: jest.fn().mockResolvedValue(mockUserCampaign),
+        save: jest.fn().mockImplementation(async (entity) => entity),
+      };
+
+      // Spending 15 GBP on products
+      await service.spend(
+        'uc1',
+        mockUser,
+        15,
+        SpendingChannel.ONLINE,
+        CampaignUsageType.ORDER_PRODUCT,
+        mockManager as any,
+      );
+
+      expect(Number(mockWallet.value1Balance)).toBe(0); // 10 exhausted
+      expect(Number(mockWallet.value2Balance)).toBe(5); // 5 more deducted
+      expect(Number(mockWallet.value3Balance)).toBe(10); // Untouched
+    });
+
+    it('should throw error if campaign is expired', async () => {
+      const expiredCampaign = {
+        startDate: new Date(now.getTime() - 20000),
+        endDate: new Date(now.getTime() - 10000),
+      };
+      const mockUserCampaign = { id: 'uc1', campaign: expiredCampaign };
+
+      const mockManager = {
+        findOne: jest.fn().mockResolvedValue(mockUserCampaign),
+      };
+
+      await expect(
+        service.spend(
+          'uc1',
+          mockUser,
+          5,
+          SpendingChannel.ONLINE,
+          CampaignUsageType.ORDER_PRODUCT,
+          mockManager as any,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.service.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/campaign-cashback.service.ts
@@ -1,0 +1,491 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Inject,
+  forwardRef,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import {
+  Repository,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  DataSource,
+  EntityManager,
+} from 'typeorm';
+import { CampaignCashback } from './entities/campaign-cashback.entity';
+import { UserCampaignCashback } from './entities/user-campaign-cashback.entity';
+import { UserCampaignWallet } from './entities/user-campaign-wallet.entity';
+import { CreateCampaignCashbackDto } from './dto/create-campaign-cashback.dto';
+import { User } from '../users/entities/user.entity';
+import {
+  CampaignStatus,
+  SpendingChannel,
+  CampaignTargetType,
+  CampaignCategory,
+  CampaignUnlockMode,
+  CampaignUsageType,
+} from './campaign-cashback.enum';
+import {
+  ContributeDto,
+  ContributionPaymentProvider,
+} from './dto/contribute.dto';
+import { Season } from '../seasons/entities/season.entity';
+import { WalletService } from '../wallet/wallet.service';
+import { WalletTransactionType } from '../wallet/entities/wallet-transaction.entity';
+import { PaymentProviderService } from '../payments/services/payment-provider.service';
+import {
+  OrderPayment,
+  PaymentMethod,
+} from '../order/entities/order-payment.entity';
+import { UserRole } from '../../common/role.enum';
+
+@Injectable()
+export class CampaignCashbackService {
+  constructor(
+    @InjectRepository(CampaignCashback)
+    private campaignRepository: Repository<CampaignCashback>,
+    @InjectRepository(UserCampaignCashback)
+    private userCampaignRepository: Repository<UserCampaignCashback>,
+    @InjectRepository(UserCampaignWallet)
+    private walletRepository: Repository<UserCampaignWallet>,
+    @InjectRepository(Season)
+    private seasonRepository: Repository<Season>,
+    @InjectRepository(OrderPayment)
+    private orderPaymentRepository: Repository<OrderPayment>,
+    @Inject(forwardRef(() => WalletService))
+    private walletService: WalletService,
+    private paymentProviderService: PaymentProviderService,
+    private dataSource: DataSource,
+  ) {}
+
+  async create(
+    createDto: CreateCampaignCashbackDto,
+  ): Promise<CampaignCashback> {
+    const levelValue = createDto.totalValue / 3;
+
+    let startDate: Date;
+    let endDate: Date;
+    let season: Season = null;
+
+    if (createDto.type === CampaignCategory.SEASONAL) {
+      if (!createDto.seasonId) {
+        throw new BadRequestException(
+          'Season ID is required for seasonal campaigns',
+        );
+      }
+      season = await this.seasonRepository.findOne({
+        where: { id: createDto.seasonId },
+      });
+      if (!season) {
+        throw new NotFoundException('Season not found');
+      }
+      startDate = season.startDate;
+      endDate = season.endDate;
+    } else {
+      if (!createDto.startDate || !createDto.endDate) {
+        throw new BadRequestException(
+          'Start and end dates are required for regular campaigns',
+        );
+      }
+      startDate = new Date(createDto.startDate);
+      endDate = new Date(createDto.endDate);
+    }
+
+    const campaign = this.campaignRepository.create({
+      ...createDto,
+      levelValue,
+      startDate,
+      endDate,
+      season,
+    });
+    return this.campaignRepository.save(campaign);
+  }
+
+  async findAllForUser(user: User, targetType?: CampaignTargetType) {
+    const now = new Date();
+
+    // 1. Fetch active campaigns based on date
+    const allCampaigns = await this.campaignRepository.find({
+      where: {
+        startDate: LessThanOrEqual(now),
+        endDate: MoreThanOrEqual(now),
+      },
+    });
+
+    // 2. Logic for audience targeting
+    const eligibleCampaigns = allCampaigns.filter((c) => {
+      // If user is filtering by a specific type (e.g. B2B tab), check it
+      if (targetType && c.targetType !== targetType) return false;
+
+      // Check logic based on CampaignTargetType
+      switch (c.targetType) {
+        case CampaignTargetType.ALL:
+          return true;
+        case CampaignTargetType.CUSTOMER:
+          return user.role === UserRole.CUSTOMER;
+        case CampaignTargetType.BUSINESS:
+          return user.role === UserRole.OWNER;
+        case CampaignTargetType.SPECIFIC_USERS:
+          return c.targetIds && c.targetIds.includes(user.id);
+        default:
+          return false;
+      }
+    });
+
+    const userCampaigns: UserCampaignCashback[] = [];
+
+    for (const campaign of eligibleCampaigns) {
+      // Load userCampaign instance with wallets
+      let userCampaign = await this.userCampaignRepository.findOne({
+        where: { user: { id: user.id }, campaign: { id: campaign.id } },
+        relations: ['campaign', 'wallets'],
+      });
+
+      if (!userCampaign) {
+        // Automatically activate campaign if user is eligible but hasn't accessed it yet
+        userCampaign = await this.createUserCampaign(user, campaign);
+      }
+      userCampaigns.push(userCampaign);
+    }
+
+    return userCampaigns;
+  }
+
+  private async createUserCampaign(
+    user: User,
+    campaign: CampaignCashback,
+  ): Promise<UserCampaignCashback> {
+    const userCampaign = this.userCampaignRepository.create({
+      user,
+      campaign,
+      status: CampaignStatus.ACTIVE,
+      contributionPaid: false,
+      activationTimerDate: campaign.activationTimerDays
+        ? new Date(
+            Date.now() + campaign.activationTimerDays * 24 * 60 * 60 * 1000,
+          )
+        : null,
+    });
+
+    const savedUserCampaign =
+      await this.userCampaignRepository.save(userCampaign);
+
+    // Initialize multi-bucket wallets based on campaign channel configuration
+    const allChannels = new Set<SpendingChannel>();
+    if (campaign.value1Channels)
+      campaign.value1Channels.forEach((c) => allChannels.add(c));
+    if (campaign.value2Channels)
+      campaign.value2Channels.forEach((c) => allChannels.add(c));
+    if (campaign.value3Channels)
+      campaign.value3Channels.forEach((c) => allChannels.add(c));
+
+    const wallets: UserCampaignWallet[] = [];
+    for (const channel of Array.from(allChannels)) {
+      const wallet = this.walletRepository.create({
+        userCampaign: savedUserCampaign,
+        channelType: channel,
+        value1Balance: this.calculateChannelBalance(
+          channel,
+          campaign.value1Channels,
+          campaign.levelValue,
+        ),
+        value2Balance: this.calculateChannelBalance(
+          channel,
+          campaign.value2Channels,
+          campaign.levelValue,
+        ),
+        value3Balance: this.calculateChannelBalance(
+          channel,
+          campaign.value3Channels,
+          campaign.levelValue,
+        ),
+      });
+      wallets.push(wallet);
+    }
+
+    await this.walletRepository.save(wallets);
+    savedUserCampaign.wallets = wallets;
+    return savedUserCampaign;
+  }
+
+  private calculateChannelBalance(
+    channel: SpendingChannel,
+    allowedChannels: SpendingChannel[],
+    totalLevelValue: number,
+  ): number {
+    // Safety check to prevent division by zero or errors on empty channel lists
+    if (
+      !allowedChannels ||
+      allowedChannels.length === 0 ||
+      !allowedChannels.includes(channel)
+    )
+      return 0;
+    return totalLevelValue / allowedChannels.length;
+  }
+
+  async findOne(id: string, user: User): Promise<UserCampaignCashback> {
+    const userCampaign = await this.userCampaignRepository.findOne({
+      where: { id, user: { id: user.id } },
+      relations: ['campaign', 'wallets'],
+    });
+
+    if (!userCampaign) {
+      throw new NotFoundException('Campaign cashback not found');
+    }
+
+    return userCampaign;
+  }
+
+  async contribute(
+    id: string,
+    user: User,
+    contributeDto: ContributeDto,
+  ): Promise<UserCampaignCashback> {
+    const currency = 'GBP';
+
+    // 1. Initial basic validation (pre-lock)
+    const userCampaignCheck = await this.findOne(id, user);
+    if (userCampaignCheck.contributionPaid) {
+      throw new BadRequestException('Contribution already paid');
+    }
+
+    const campaign = userCampaignCheck.campaign;
+    if (contributeDto.amount < campaign.levelValue) {
+      throw new BadRequestException(
+        `Contribution amount must be at least £${campaign.levelValue}`,
+      );
+    }
+
+    // 2. EXTERNAL VERIFICATION (Outside DB Transaction to prevent deadlocks and performance degradation)
+    if (contributeDto.paymentMethod === ContributionPaymentProvider.STRIPE) {
+      if (!contributeDto.transactionId)
+        throw new BadRequestException('Transaction ID is required');
+
+      // Idempotency check 1
+      const existingPayment = await this.orderPaymentRepository.findOne({
+        where: { transactionId: contributeDto.transactionId },
+      });
+      if (existingPayment)
+        throw new BadRequestException('Transaction already processed');
+
+      const result =
+        await this.paymentProviderService.verifyStripePaymentIntent(
+          contributeDto.transactionId,
+          contributeDto.amount,
+          currency,
+        );
+      if (!result.ok)
+        throw new BadRequestException(
+          `Stripe verification failed: ${result.reason}`,
+        );
+    } else if (
+      contributeDto.paymentMethod === ContributionPaymentProvider.PAYPAL
+    ) {
+      if (!contributeDto.transactionId)
+        throw new BadRequestException('Transaction ID is required');
+
+      // Idempotency check 1
+      const existingPayment = await this.orderPaymentRepository.findOne({
+        where: { transactionId: contributeDto.transactionId },
+      });
+      if (existingPayment)
+        throw new BadRequestException('Transaction already processed');
+
+      const result =
+        await this.paymentProviderService.captureAndVerifyPaypalOrder(
+          contributeDto.transactionId,
+          contributeDto.amount,
+          currency,
+        );
+      if (!result.ok)
+        throw new BadRequestException(
+          `PayPal verification failed: ${result.reason}`,
+        );
+    }
+
+    // 3. SECURE UPDATE (Inside Transaction with Pessimistic Lock)
+    return this.dataSource.transaction(async (manager) => {
+      // Fix: Lock the entity by ID directly to avoid "FOR UPDATE on outer join" error
+      const lockedCampaign = await manager.findOne(UserCampaignCashback, {
+        where: { id },
+        lock: { mode: 'pessimistic_write' },
+      });
+
+      if (!lockedCampaign)
+        throw new NotFoundException('Campaign not found during processing');
+
+      // Basic security check: ensure it belongs to the user
+      // (This should have been caught by the pre-lock findOne, but double check)
+      const userCampaign = await manager.findOne(UserCampaignCashback, {
+        where: { id, user: { id: user.id } },
+        relations: ['campaign', 'wallets'],
+      });
+
+      if (!userCampaign)
+        throw new NotFoundException('Campaign not found for this user');
+      if (userCampaign.contributionPaid) return userCampaign; // Concurrent request already succeeded
+
+      // Final Idempotency Check for external payments inside the lock
+      if (contributeDto.transactionId) {
+        const doubleCheckPayment = await manager.findOne(OrderPayment, {
+          where: { transactionId: contributeDto.transactionId },
+        });
+        if (doubleCheckPayment)
+          throw new BadRequestException(
+            'Transaction was processed by a concurrent request',
+          );
+      }
+
+      if (contributeDto.paymentMethod === ContributionPaymentProvider.WALLET) {
+        // Wallet spend is safe inside transaction as it manages its own balance updates
+        await this.walletService.spendBalance(
+          user.id,
+          contributeDto.amount,
+          `Contribution for campaign: ${campaign.name}`,
+          WalletTransactionType.CAMPAIGN_CASHBACK_CONTRIBUTION,
+          manager,
+        );
+      } else {
+        // Record successful external payment in DB
+        const paymentMethod =
+          contributeDto.paymentMethod === ContributionPaymentProvider.STRIPE
+            ? PaymentMethod.STRIPE
+            : PaymentMethod.PAYPAL;
+        const payment = manager.create(OrderPayment, {
+          user: { id: user.id } as User,
+          amount: contributeDto.amount,
+          currency,
+          transactionId: contributeDto.transactionId,
+          paymentMethod,
+        });
+        await manager.save(payment);
+      }
+
+      userCampaign.contributionPaid = true;
+      return manager.save(userCampaign);
+    });
+  }
+
+  async spend(
+    id: string,
+    user: User,
+    amount: number,
+    channel: SpendingChannel,
+    usageType: CampaignUsageType,
+    manager?: EntityManager,
+  ): Promise<UserCampaignCashback> {
+    const finalManager = manager || this.dataSource.manager;
+
+    // 1. Fetch user campaign with wallets and lock if in transaction
+    // Fix: Lock by ID first if manager is provided (meaning we are in a transaction)
+    if (manager) {
+      await manager.findOne(UserCampaignCashback, {
+        where: { id },
+        lock: { mode: 'pessimistic_write' },
+      });
+    }
+
+    const userCampaign = await finalManager.findOne(UserCampaignCashback, {
+      where: { id, user: { id: user.id } },
+      relations: ['campaign', 'wallets'],
+    });
+
+    if (!userCampaign) throw new NotFoundException('Campaign card not found');
+
+    const campaign = userCampaign.campaign;
+
+    // 2. Validate Campaign Status & Dates
+    const now = new Date();
+    if (now < campaign.startDate || now > campaign.endDate) {
+      throw new BadRequestException('Campaign is not currently active');
+    }
+
+    if (
+      campaign.unlockMode === CampaignUnlockMode.REQUIRE_FULL_UNLOCK &&
+      !userCampaign.contributionPaid
+    ) {
+      throw new BadRequestException(
+        'Campaign card must be unlocked with a contribution before usage',
+      );
+    }
+
+    // 3. Find correct channel wallet
+    const wallet = userCampaign.wallets.find((w) => w.channelType === channel);
+    if (!wallet)
+      throw new BadRequestException(
+        `This campaign card is not valid for ${channel} spending`,
+      );
+
+    // 4. Calculate total available based on Usage Type permissions
+    let remainingToDeduct = amount;
+
+    // Value 1 Check
+    if (
+      campaign.value1UsageTypes.includes(usageType) ||
+      campaign.value1UsageTypes.includes(CampaignUsageType.ANYWHERE)
+    ) {
+      const canDeduct = Math.min(
+        remainingToDeduct,
+        Number(wallet.value1Balance),
+      );
+      wallet.value1Balance = Number(wallet.value1Balance) - canDeduct;
+      remainingToDeduct -= canDeduct;
+    }
+
+    // Value 2 Check
+    if (
+      remainingToDeduct > 0 &&
+      (campaign.value2UsageTypes.includes(usageType) ||
+        campaign.value2UsageTypes.includes(CampaignUsageType.ANYWHERE))
+    ) {
+      const canDeduct = Math.min(
+        remainingToDeduct,
+        Number(wallet.value2Balance),
+      );
+      wallet.value2Balance = Number(wallet.value2Balance) - canDeduct;
+      remainingToDeduct -= canDeduct;
+    }
+
+    // Value 3 Check (Requires contribution paid if allowed only after unlock)
+    if (
+      remainingToDeduct > 0 &&
+      userCampaign.contributionPaid &&
+      (campaign.value3UsageTypes.includes(usageType) ||
+        campaign.value3UsageTypes.includes(CampaignUsageType.ANYWHERE))
+    ) {
+      const canDeduct = Math.min(
+        remainingToDeduct,
+        Number(wallet.value3Balance),
+      );
+      wallet.value3Balance = Number(wallet.value3Balance) - canDeduct;
+      remainingToDeduct -= canDeduct;
+    }
+
+    if (remainingToDeduct > 0) {
+      throw new BadRequestException(
+        'Insufficient campaign cashback balance for this usage type/channel',
+      );
+    }
+
+    // 5. Update Status based on usage
+    const totalRemaining =
+      Number(wallet.value1Balance) +
+      Number(wallet.value2Balance) +
+      Number(wallet.value3Balance);
+    if (totalRemaining === 0) {
+      userCampaign.status = CampaignStatus.FULLY_USED;
+    } else {
+      userCampaign.status = CampaignStatus.PARTIALLY_USED;
+    }
+
+    await finalManager.save(wallet);
+    return finalManager.save(userCampaign);
+  }
+
+  async remove(id: string): Promise<void> {
+    const campaign = await this.campaignRepository.findOne({ where: { id } });
+    if (!campaign) throw new NotFoundException('Campaign not found');
+    await this.campaignRepository.remove(campaign);
+  }
+}

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/dto/contribute.dto.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/dto/contribute.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString, IsEnum, IsOptional } from 'class-validator';
+
+export enum ContributionPaymentProvider {
+  STRIPE = 'stripe',
+  PAYPAL = 'paypal',
+  WALLET = 'wallet',
+}
+
+export class ContributeDto {
+  @ApiProperty({
+    example: 10,
+    description: 'The exact amount to contribute (should be 1/3 of totalValue)',
+  })
+  @IsNumber()
+  amount: number;
+
+  @ApiProperty({
+    enum: ContributionPaymentProvider,
+    example: ContributionPaymentProvider.STRIPE,
+    description: 'Payment method used: stripe, paypal, or wallet',
+  })
+  @IsEnum(ContributionPaymentProvider)
+  paymentMethod: ContributionPaymentProvider;
+
+  @ApiProperty({
+    example: 'pi_3O8abc123xyz',
+    description:
+      'Transaction ID from external provider (required for stripe/paypal)',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  transactionId?: string;
+}

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/dto/create-campaign-cashback.dto.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/dto/create-campaign-cashback.dto.ts
@@ -1,0 +1,253 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateIf,
+} from 'class-validator';
+import {
+  CampaignTargetType,
+  CampaignDisplayType,
+  CampaignUnlockMode,
+  SpendingChannel,
+  CampaignCategory,
+  CampaignUsageType,
+} from '../campaign-cashback.enum';
+
+export class CreateCampaignCashbackDto {
+  @ApiProperty({
+    example: 'Spring 2026 Promo',
+    description: 'The name of the campaign',
+  })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    enum: CampaignCategory,
+    example: CampaignCategory.REGULAR,
+    description: 'Type of campaign (REGULAR or SEASONAL)',
+  })
+  @IsEnum(CampaignCategory)
+  type: CampaignCategory;
+
+  @ApiProperty({
+    description: 'Season ID (required if type is SEASONAL)',
+    required: false,
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ValidateIf((o) => o.type === CampaignCategory.SEASONAL)
+  @IsString()
+  seasonId?: string;
+
+  @ApiProperty({
+    description: 'Start date (required if type is REGULAR)',
+    required: false,
+    example: '2026-03-01T00:00:00Z',
+  })
+  @ValidateIf((o) => o.type === CampaignCategory.REGULAR)
+  @IsDateString()
+  startDate?: string;
+
+  @ApiProperty({
+    description: 'End date (required if type is REGULAR)',
+    required: false,
+    example: '2026-04-01T23:59:59Z',
+  })
+  @ValidateIf((o) => o.type === CampaignCategory.REGULAR)
+  @IsDateString()
+  endDate?: string;
+
+  @ApiProperty({
+    enum: CampaignTargetType,
+    example: CampaignTargetType.CUSTOMER,
+    description:
+      'Target audience type (CUSTOMER, BUSINESS, ALL, SPECIFIC_USERS)',
+  })
+  @IsEnum(CampaignTargetType)
+  targetType: CampaignTargetType;
+
+  @ApiProperty({
+    enum: CampaignDisplayType,
+    example: CampaignDisplayType.E_CARD,
+    description: 'UI display style (VOUCHER or E_CARD)',
+  })
+  @IsEnum(CampaignDisplayType)
+  displayType: CampaignDisplayType;
+
+  @ApiProperty({
+    example: 30,
+    description: 'Total face value of the campaign cashback',
+  })
+  @IsNumber()
+  totalValue: number;
+
+  @ApiProperty({
+    enum: CampaignUnlockMode,
+    example: CampaignUnlockMode.REQUIRE_FULL_UNLOCK,
+    description:
+      'Unlock strategy: REQUIRE_FULL_UNLOCK (must pay 1/3 first) or ALLOW_PRELOADED_USAGE (can use 2/3 immediately)',
+  })
+  @IsEnum(CampaignUnlockMode)
+  unlockMode: CampaignUnlockMode;
+
+  @ApiProperty({
+    example: '2026-12-31T23:59:59Z',
+    description: 'When the card itself expires',
+  })
+  @IsDateString()
+  expiryDate: string;
+
+  @ApiProperty({
+    required: false,
+    example: 30,
+    description: 'Number of days user has to complete tasks after activation',
+  })
+  @IsNumber()
+  @IsOptional()
+  activationTimerDays?: number;
+
+  @ApiProperty({
+    type: [String],
+    required: false,
+    example: ['WATCH_VIDEO', 'COMPLETE_SURVEY'],
+    description: 'Tasks user must perform',
+  })
+  @IsArray()
+  @IsOptional()
+  activationTasks?: string[];
+
+  @ApiProperty({
+    required: false,
+    example: false,
+    description: 'Is this an external partner campaign?',
+  })
+  @IsBoolean()
+  @IsOptional()
+  externalCampaign?: boolean;
+
+  @ApiProperty({
+    required: false,
+    example: 'https://partner.com/redeem',
+    description: 'URL for external redemption',
+  })
+  @IsString()
+  @IsOptional()
+  externalRedemptionUrl?: string;
+
+  // Value 1 Config
+  @ApiProperty({ example: '247GBS Cashback' })
+  @IsString()
+  value1Title: string;
+
+  @ApiProperty({ example: 'Funded by 247GBS for local shopping.' })
+  @IsString()
+  value1Description: string;
+
+  @ApiProperty({ example: 'Redeemable at participating stores.' })
+  @IsString()
+  value1UsageText: string;
+
+  @ApiProperty({
+    enum: SpendingChannel,
+    isArray: true,
+    example: [SpendingChannel.HYPERLOCAL],
+  })
+  @IsArray()
+  @IsEnum(SpendingChannel, { each: true })
+  value1Channels: SpendingChannel[];
+
+  @ApiProperty({
+    enum: CampaignUsageType,
+    isArray: true,
+    example: [CampaignUsageType.ORDER_PRODUCT],
+  })
+  @IsArray()
+  @IsEnum(CampaignUsageType, { each: true })
+  value1UsageTypes: CampaignUsageType[];
+
+  // Value 2 Config
+  @ApiProperty({ example: 'System Bonus' })
+  @IsString()
+  value2Title: string;
+
+  @ApiProperty({ example: 'Internal system reward.' })
+  @IsString()
+  value2Description: string;
+
+  @ApiProperty({ example: 'Use for online services.' })
+  @IsString()
+  value2UsageText: string;
+
+  @ApiProperty({
+    enum: SpendingChannel,
+    isArray: true,
+    example: [SpendingChannel.ONLINE],
+  })
+  @IsArray()
+  @IsEnum(SpendingChannel, { each: true })
+  value2Channels: SpendingChannel[];
+
+  @ApiProperty({
+    enum: CampaignUsageType,
+    isArray: true,
+    example: [CampaignUsageType.BOOK_SERVICE],
+  })
+  @IsArray()
+  @IsEnum(CampaignUsageType, { each: true })
+  value2UsageTypes: CampaignUsageType[];
+
+  // Value 3 Config
+  @ApiProperty({ example: 'Your Contribution' })
+  @IsString()
+  value3Title: string;
+
+  @ApiProperty({ example: 'The portion you paid.' })
+  @IsString()
+  value3Description: string;
+
+  @ApiProperty({ example: 'Use anywhere on the platform.' })
+  @IsString()
+  value3UsageText: string;
+
+  @ApiProperty({
+    enum: SpendingChannel,
+    isArray: true,
+    example: [
+      SpendingChannel.ONLINE,
+      SpendingChannel.HYPERLOCAL,
+      SpendingChannel.NEARBY,
+    ],
+  })
+  @IsArray()
+  @IsEnum(SpendingChannel, { each: true })
+  value3Channels: SpendingChannel[];
+
+  @ApiProperty({
+    enum: CampaignUsageType,
+    isArray: true,
+    example: [CampaignUsageType.ANYWHERE],
+  })
+  @IsArray()
+  @IsEnum(CampaignUsageType, { each: true })
+  value3UsageTypes: CampaignUsageType[];
+
+  @ApiProperty({
+    default: true,
+    description: 'Apply to all users of the target type',
+  })
+  @IsBoolean()
+  selectAll: boolean;
+
+  @ApiProperty({
+    type: [String],
+    required: false,
+    description: 'Specific User IDs if selectAll is false',
+  })
+  @IsArray()
+  @IsOptional()
+  targetIds?: string[];
+}

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/entities/campaign-cashback.entity.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/entities/campaign-cashback.entity.ts
@@ -1,0 +1,117 @@
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { AbstractBaseEntity } from '../../../database/entities/base.entity';
+import {
+  CampaignTargetType,
+  CampaignDisplayType,
+  CampaignUnlockMode,
+  SpendingChannel,
+  CampaignCategory,
+  CampaignUsageType,
+} from '../campaign-cashback.enum';
+import { Season } from '../../seasons/entities/season.entity';
+
+@Entity('campaign_cashbacks')
+export class CampaignCashback extends AbstractBaseEntity {
+  @Column()
+  name: string;
+
+  @Column({
+    type: 'enum',
+    enum: CampaignCategory,
+    default: CampaignCategory.REGULAR,
+  })
+  type: CampaignCategory;
+
+  @ManyToOne(() => Season, { nullable: true })
+  season: Season;
+
+  @Column({ type: 'timestamp' })
+  startDate: Date;
+
+  @Column({ type: 'timestamp' })
+  endDate: Date;
+
+  @Column({
+    type: 'enum',
+    enum: CampaignTargetType,
+    default: CampaignTargetType.CUSTOMER,
+  })
+  targetType: CampaignTargetType;
+
+  @Column({
+    type: 'enum',
+    enum: CampaignDisplayType,
+    default: CampaignDisplayType.VOUCHER,
+  })
+  displayType: CampaignDisplayType;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  totalValue: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  levelValue: number;
+
+  @Column({
+    type: 'enum',
+    enum: CampaignUnlockMode,
+    default: CampaignUnlockMode.REQUIRE_FULL_UNLOCK,
+  })
+  unlockMode: CampaignUnlockMode;
+
+  @Column({ type: 'timestamp' })
+  expiryDate: Date;
+
+  @Column({ default: 0 })
+  activationTimerDays: number;
+
+  @Column('simple-array', { nullable: true })
+  activationTasks: string[];
+
+  @Column({ default: false })
+  externalCampaign: boolean;
+
+  @Column({ nullable: true })
+  externalRedemptionUrl: string;
+
+  // Value 1 Config
+  @Column()
+  value1Title: string;
+  @Column('text')
+  value1Description: string;
+  @Column()
+  value1UsageText: string;
+  @Column('simple-array', { nullable: true })
+  value1Channels: SpendingChannel[];
+  @Column('simple-array', { nullable: true })
+  value1UsageTypes: CampaignUsageType[];
+
+  // Value 2 Config
+  @Column()
+  value2Title: string;
+  @Column('text')
+  value2Description: string;
+  @Column()
+  value2UsageText: string;
+  @Column('simple-array', { nullable: true })
+  value2Channels: SpendingChannel[];
+  @Column('simple-array', { nullable: true })
+  value2UsageTypes: CampaignUsageType[];
+
+  // Value 3 Config
+  @Column()
+  value3Title: string;
+  @Column('text')
+  value3Description: string;
+  @Column()
+  value3UsageText: string;
+  @Column('simple-array', { nullable: true })
+  value3Channels: SpendingChannel[];
+  @Column('simple-array', { nullable: true })
+  value3UsageTypes: CampaignUsageType[];
+
+  @Column({ default: true })
+  selectAll: boolean;
+
+  @Column('simple-array', { nullable: true })
+  targetIds: string[];
+}

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/entities/user-campaign-cashback.entity.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/entities/user-campaign-cashback.entity.ts
@@ -1,0 +1,33 @@
+import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import { AbstractBaseEntity } from '../../../database/entities/base.entity';
+import { CampaignStatus } from '../campaign-cashback.enum';
+import { CampaignCashback } from './campaign-cashback.entity';
+import { User } from '../../users/entities/user.entity';
+import { UserCampaignWallet } from './user-campaign-wallet.entity';
+
+@Entity('user_campaign_cashbacks')
+export class UserCampaignCashback extends AbstractBaseEntity {
+  @ManyToOne(() => User)
+  user: User;
+
+  @ManyToOne(() => CampaignCashback)
+  campaign: CampaignCashback;
+
+  @Column({
+    type: 'enum',
+    enum: CampaignStatus,
+    default: CampaignStatus.ACTIVE,
+  })
+  status: CampaignStatus;
+
+  @Column({ default: false })
+  contributionPaid: boolean;
+
+  @OneToMany(() => UserCampaignWallet, (wallet) => wallet.userCampaign, {
+    cascade: true,
+  })
+  wallets: UserCampaignWallet[];
+
+  @Column({ type: 'timestamp', nullable: true })
+  activationTimerDate: Date;
+}

--- a/apps/mcom_mallAPI/src/resources/campaign-cashback/entities/user-campaign-wallet.entity.ts
+++ b/apps/mcom_mallAPI/src/resources/campaign-cashback/entities/user-campaign-wallet.entity.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { AbstractBaseEntity } from '../../../database/entities/base.entity';
+import { SpendingChannel } from '../campaign-cashback.enum';
+import { UserCampaignCashback } from './user-campaign-cashback.entity';
+
+@Entity('user_campaign_wallets')
+export class UserCampaignWallet extends AbstractBaseEntity {
+  @ManyToOne(() => UserCampaignCashback, (uc) => uc.wallets, {
+    onDelete: 'CASCADE',
+  })
+  userCampaign: UserCampaignCashback;
+
+  @Column({
+    type: 'enum',
+    enum: SpendingChannel,
+  })
+  channelType: SpendingChannel;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+  value1Balance: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+  value2Balance: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 0 })
+  value3Balance: number;
+}

--- a/apps/mcom_mallAPI/src/resources/checkout/dto/complete-checkout.dto.ts
+++ b/apps/mcom_mallAPI/src/resources/checkout/dto/complete-checkout.dto.ts
@@ -31,4 +31,11 @@ export class CompleteCheckoutDto {
   @IsString()
   @IsNotEmpty()
   transactionId?: string;
+
+  @ApiPropertyOptional({
+    description: 'The ID of the User Campaign Cashback to use for payment.',
+  })
+  @IsUUID()
+  @IsOptional()
+  campaignCashbackId?: string;
 }

--- a/apps/mcom_mallAPI/src/resources/checkout/dto/create-checkout.dto.ts
+++ b/apps/mcom_mallAPI/src/resources/checkout/dto/create-checkout.dto.ts
@@ -46,4 +46,11 @@ export class CreateCheckoutDto {
   @IsString()
   @IsOptional()
   couponCode?: string;
+
+  @ApiPropertyOptional({
+    description: 'The ID of the User Campaign Cashback to use for payment.',
+  })
+  @IsUUID()
+  @IsOptional()
+  campaignCashbackId?: string;
 }

--- a/apps/mcom_mallAPI/src/resources/wallet/entities/wallet-transaction.entity.ts
+++ b/apps/mcom_mallAPI/src/resources/wallet/entities/wallet-transaction.entity.ts
@@ -14,6 +14,7 @@ export enum WalletTransactionType {
   SPEND = 'spend',
   FUNDING = 'funding',
   ADJUSTMENT = 'adjustment',
+  CAMPAIGN_CASHBACK_CONTRIBUTION = 'campaign_cashback_contribution',
 }
 
 @Entity('wallet_transactions')

--- a/apps/mcom_mallAPI/src/resources/wallet/wallet.service.ts
+++ b/apps/mcom_mallAPI/src/resources/wallet/wallet.service.ts
@@ -428,6 +428,43 @@ export class WalletService {
     });
   }
 
+  async spendBalance(
+    userId: string,
+    amount: number,
+    description: string,
+    type: WalletTransactionType = WalletTransactionType.SPEND,
+    manager?: EntityManager,
+  ): Promise<Wallet> {
+    const finalManager = manager || this.dataSource.manager;
+    const walletRepo = finalManager.getRepository(Wallet);
+
+    const wallet = await walletRepo.findOne({
+      where: { user: { id: userId } },
+    });
+
+    if (!wallet) {
+      throw new NotFoundException('Wallet not found');
+    }
+
+    if (Number(wallet.spendableBalance) < amount) {
+      throw new BadRequestException('Insufficient spendable balance');
+    }
+
+    wallet.spendableBalance = Number(wallet.spendableBalance) - amount;
+    const savedWallet = await walletRepo.save(wallet);
+
+    await this.createTransaction(
+      savedWallet,
+      amount,
+      type,
+      description,
+      savedWallet.spendableBalance,
+      finalManager,
+    );
+
+    return savedWallet;
+  }
+
   private async createTransaction(
     wallet: Wallet,
     amount: number,

--- a/apps/mcom_mallAPI/test/campaign-cashback.e2e-spec.ts
+++ b/apps/mcom_mallAPI/test/campaign-cashback.e2e-spec.ts
@@ -1,0 +1,190 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { UserRole } from '../src/common/role.enum';
+import {
+  CampaignTargetType,
+  CampaignDisplayType,
+  CampaignUnlockMode,
+  SpendingChannel,
+  CampaignCategory,
+  CampaignUsageType,
+} from '../src/resources/campaign-cashback/campaign-cashback.enum';
+import { ContributionPaymentProvider } from '../src/resources/campaign-cashback/dto/contribute.dto';
+import { PaymentProviderService } from '../src/resources/payments/services/payment-provider.service';
+import { EmailService } from '../src/resources/email/email.service';
+
+/**
+ * E2E TESTS: CampaignCashback (Full Flow)
+ */
+
+describe('CampaignCashback (e2e)', () => {
+  let app: INestApplication;
+  let adminToken: string;
+  let userToken: string;
+  let paymentProviderService: PaymentProviderService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(EmailService)
+      .useValue({
+        sendUserWelcomeEmail: jest.fn().mockResolvedValue({}),
+        sendOtp: jest.fn().mockResolvedValue({}),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+
+    paymentProviderService = moduleFixture.get<PaymentProviderService>(
+      PaymentProviderService,
+    );
+
+    await app.init();
+
+    const adminEmail = `admin-${Date.now()}@test.com`;
+    const userEmail = `user-${Date.now()}@test.com`;
+    const password = 'Password123!';
+
+    // Fix: Use correct endpoint /users/create
+    const adminCreate = await request(app.getHttpServer())
+      .post('/users/create')
+      .send({
+        firstName: 'Admin',
+        lastName: 'Cash',
+        email: adminEmail,
+        password,
+        confirm_password: password,
+        phoneNumber: `A${Date.now()}`,
+        role: UserRole.ADMIN,
+      });
+
+    if (adminCreate.status !== 201) {
+      console.error('Admin Create Failed:', adminCreate.body);
+    }
+
+    const userCreate = await request(app.getHttpServer())
+      .post('/users/create')
+      .send({
+        firstName: 'User',
+        lastName: 'Cash',
+        email: userEmail,
+        password,
+        confirm_password: password,
+        phoneNumber: `U${Date.now()}`,
+        role: UserRole.CUSTOMER,
+      });
+
+    if (userCreate.status !== 201) {
+      console.error('User Create Failed:', userCreate.body);
+    }
+
+    const adminAuth = await request(app.getHttpServer())
+      .post('/auth')
+      .send({ email: adminEmail, password });
+    const userAuth = await request(app.getHttpServer())
+      .post('/auth')
+      .send({ email: userEmail, password });
+
+    if (!adminAuth.body.auth || !userAuth.body.auth) {
+      console.error('Auth Failed:', {
+        admin: adminAuth.body,
+        user: userAuth.body,
+      });
+      throw new Error('Authentication failed during setup');
+    }
+
+    adminToken = adminAuth.body.auth.accessToken;
+    userToken = userAuth.body.auth.accessToken;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('Scenario 1: Full Creation and Activation Flow', async () => {
+    const now = new Date();
+    const startDate = new Date(now.getTime() - 3600000).toISOString();
+    const endDate = new Date(now.getTime() + 86400000).toISOString();
+
+    const createDto = {
+      name: 'E2E Integrated Campaign',
+      type: CampaignCategory.REGULAR,
+      startDate,
+      endDate,
+      targetType: CampaignTargetType.CUSTOMER,
+      displayType: CampaignDisplayType.E_CARD,
+      totalValue: 30,
+      unlockMode: CampaignUnlockMode.REQUIRE_FULL_UNLOCK,
+      expiryDate: new Date(Date.now() + 86400000).toISOString(),
+      value1Title: 'V1',
+      value1Description: 'D1',
+      value1UsageText: 'U1',
+      value1Channels: [SpendingChannel.ONLINE],
+      value1UsageTypes: [CampaignUsageType.ORDER_PRODUCT],
+      value2Title: 'V2',
+      value2Description: 'D2',
+      value2UsageText: 'U2',
+      value2Channels: [SpendingChannel.HYPERLOCAL],
+      value2UsageTypes: [CampaignUsageType.BOOK_SERVICE],
+      value3Title: 'V3',
+      value3Description: 'D3',
+      value3UsageText: 'U3',
+      value3Channels: [SpendingChannel.NEARBY],
+      value3UsageTypes: [CampaignUsageType.ANYWHERE],
+      selectAll: true,
+    };
+
+    await request(app.getHttpServer())
+      .post('/campaign-cashback')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send(createDto)
+      .expect(201);
+
+    const listResponse = await request(app.getHttpServer())
+      .get('/campaign-cashback')
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(200);
+
+    const userCampaign = listResponse.body.find(
+      (c) => c.campaign.name === 'E2E Integrated Campaign',
+    );
+    expect(userCampaign).toBeDefined();
+    expect(userCampaign.wallets.length).toBeGreaterThan(0);
+    expect(userCampaign.contributionPaid).toBe(false);
+
+    jest
+      .spyOn(paymentProviderService, 'verifyStripePaymentIntent')
+      .mockResolvedValue({ ok: true } as any);
+
+    await request(app.getHttpServer())
+      .post(`/campaign-cashback/${userCampaign.id}/contribute`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        amount: 10,
+        paymentMethod: ContributionPaymentProvider.STRIPE,
+        transactionId: `e2e_tx_stripe_${Date.now()}`,
+      })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post(`/campaign-cashback/${userCampaign.id}/contribute`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .send({
+        amount: 10,
+        paymentMethod: ContributionPaymentProvider.STRIPE,
+        transactionId: `e2e_tx_stripe_${Date.now()}`,
+      })
+      .expect(400);
+
+    const finalGet = await request(app.getHttpServer())
+      .get(`/campaign-cashback/${userCampaign.id}`)
+      .set('Authorization', `Bearer ${userToken}`)
+      .expect(200);
+
+    expect(finalGet.body.contributionPaid).toBe(true);
+  });
+});


### PR DESCRIPTION
- Added CampaignCashback resource with entities, controller, and service
- Implemented 3-tier value split logic (2/3 preloaded, 1/3 contribution)
- Added multi-bucket wallet system for channel-specific isolation
- Integrated with Checkout and Booking flows for manual spending specification
- Implemented idempotent contribution logic with pessimistic locking
- Supported Regular and Seasonal campaign categories
- Expanded audience targeting (CUSTOMER, BUSINESS, ALL, SPECIFIC_USERS)
- Added comprehensive unit and E2E tests
- Generated database migrations for the new schema